### PR TITLE
DPE-48 Adding basic charm library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Tests
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:
@@ -33,12 +37,13 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox -e integration -- --model itest
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          # TEMPLATE-TODO: Replace the application name
-          app: operator-template
-          model: itest
+        # TODO set a predictable model name so it can be consumed by charm-logdump-action
+        # For now, setting one using "-- --model testing" causes it to get lost in the CI. This can be replicated locally.
+        run: tox -e integration
+      # - name: Dump logs
+      #   uses: canonical/charm-logdump-action@main
+      #   if: failure()
+      #   with:
+      #     # TEMPLATE-TODO: Replace the application name
+      #     app: operator-template
+      #     model: testing

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This charm library provides common pgbouncer-specific features for the pgbouncer machine and
+Kubernetes charms.
+"""
+
+import secrets
+import string
+from typing import Dict
+
+
+def generate_password() -> str:
+    """Generates a secure password.
+    Returns:
+        A random 24-character string of letters and numbers.
+    """
+    choices = string.ascii_letters + string.digits
+    return "".join([secrets.choice(choices) for _ in range(24)])
+
+
+def generate_pgbouncer_ini(users: Dict[str, str], config) -> str:
+    """Generate pgbouncer.ini from config.
+    This is a basic stub method, and will be updated in future to generate more complex
+    pgbouncer.ini files in a more sophisticated way.
+    Params:
+        users: a dictionary of usernames and passwords
+        config: charm config object.
+    """
+    return f"""[databases]
+{config["pgb_databases"]}
+[pgbouncer]
+listen_port = {config["pgb_listen_port"]}
+listen_addr = {config["pgb_listen_address"]}
+auth_type = md5
+auth_file = userlist.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = {",".join(users.keys())}"""
+
+
+def generate_userlist(users: Dict[str, str]) -> str:
+    """Generate userlist.txt from the given dictionary of usernames:passwords.
+    Params:
+        users: a dictionary of usernames and passwords
+    Returns:
+        A multiline string, containing each pair of usernames and passwords separated by a
+        space, one pair per line.
+    """
+    return "\n".join([f'"{username}" "{password}"' for username, password in users.items()])

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -17,11 +17,14 @@ This charm library provides common pgbouncer-specific features for the pgbouncer
 Kubernetes charms.
 """
 
+import logging
 import secrets
 import string
 from typing import Dict
 
 from ops.model import ConfigData
+
+logger = logging.getLogger(__name__)
 
 PGB_INI = """\
 [databases]
@@ -97,6 +100,7 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
     parsed_userlist = {}
     for line in userlist.split("\n"):
         if line.strip() == "" or len(line.split(" ")) != 2:
+            logger.warning("unable to parse line in userlist file - user not imported")
             continue
         # Userlist is formatted "{username}" "{password}""
         username, password = line.replace('"', "").split(" ")

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+"""PgBouncer Charm Library.
+
 This charm library provides common pgbouncer-specific features for the pgbouncer machine and
 Kubernetes charms.
 """
@@ -61,6 +62,7 @@ def generate_pgbouncer_ini(users: Dict[str, str], config: ConfigData) -> str:
 
     Args:
         users: a dictionary of usernames and passwords
+        config: A juju charm config object
     Returns:
         A multiline string defining a valid pgbouncer.ini file
     """
@@ -96,7 +98,6 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
     Returns:
         users: a dictionary of usernames and passwords
     """
-
     parsed_userlist = {}
     for line in userlist.split("\n"):
         if line.strip() == "" or len(line.split(" ")) != 2:

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -21,6 +21,8 @@ import secrets
 import string
 from typing import Dict
 
+from ops.model import ConfigData
+
 
 def generate_password() -> str:
     """Generates a secure password.
@@ -31,13 +33,16 @@ def generate_password() -> str:
     return "".join([secrets.choice(choices) for _ in range(24)])
 
 
-def generate_pgbouncer_ini(users: Dict[str, str], config) -> str:
+def generate_pgbouncer_ini(users: Dict[str, str], config: ConfigData) -> str:
     """Generate pgbouncer.ini from config.
+
     This is a basic stub method, and will be updated in future to generate more complex
     pgbouncer.ini files in a more sophisticated way.
-    Params:
+
+    Args:
         users: a dictionary of usernames and passwords
-        config: charm config object.
+    Returns:
+        A multiline string defining a valid pgbouncer.ini file
     """
     return f"""[databases]
 {config["pgb_databases"]}
@@ -53,7 +58,8 @@ admin_users = {",".join(users.keys())}"""
 
 def generate_userlist(users: Dict[str, str]) -> str:
     """Generate userlist.txt from the given dictionary of usernames:passwords.
-    Params:
+
+    Args:
         users: a dictionary of usernames and passwords
     Returns:
         A multiline string, containing each pair of usernames and passwords separated by a

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,7 @@ class OperatorTemplateCharm(CharmBase):
                 }
             },
         }
-        # Add intial Pebble config layer using the Pebble API
+        # Add initial Pebble config layer using the Pebble API
         container.add_layer("httpbin", pebble_layer, combine=True)
         # Autostart any services that were defined with startup: enabled
         container.autostart()

--- a/tests/unit/data/test_userlist.txt
+++ b/tests/unit/data/test_userlist.txt
@@ -1,0 +1,7 @@
+"testuser" "testpass"
+
+"another_testuser" "anotherpass"
+"1234" ""
+"" """
+"no""spaces"
+"too" "many" "spaces"

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -13,7 +13,9 @@ class TestPgb(unittest.TestCase):
 
     def test_generate_pgbouncer_ini(self):
         users = {"test1": "pw1", "test2": "pw2"}
-        # This should be updated to mock a juju config object
+        # Though this isn't correctly mocking an ops.model.ConfigData object, ConfigData implements
+        # a LazyMapping under the hood that accesses variables in the same way as a dictionary -
+        # they're effectively interchangeable in this context.
         config = {
             "pgb_databases": "test-dbs",
             "pgb_listen_port": "4454",

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
+import inspect
 import string
 import unittest
 
@@ -37,19 +39,20 @@ class TestPgb(unittest.TestCase):
     def test_generate_userlist(self):
         users = {"test1": "pw1", "test2": "pw2"}
         userlist = pgb.generate_userlist(users)
-        expected_userlist = '''"test1" "pw1"
-"test2" "pw2"'''
+        expected_userlist = '''"test1" "pw1"\n"test2" "pw2"'''
         self.assertEqual(userlist, expected_userlist)
 
     def test_parse_userlist(self):
-        userlist = '''"testuser" "testpass"
+        userlist = inspect.cleandoc(
+            '''"testuser" "testpass"
 
-"another_testuser" "anotherpass"
-"1234" ""
-"" """
-nospaces
-t o o m a n y s p a c e s
-'''
+            "another_testuser" "anotherpass"
+            "1234" ""
+            "" """
+            nospaces
+            t o o m a n y s p a c e s
+            '''
+        )
         users = pgb.parse_userlist(userlist)
         expected_users = {
             "testuser": "testpass",

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+from lib.charms.dp_pgbouncer_operator.v0 import pgb
+
+
+class TestPgb(unittest.TestCase):
+    def test_generate_password(self):
+        pw = pgb.generate_password()
+        self.assertEqual(len(pw), 24)
+
+    def test_generate_pgbouncer_ini(self):
+        users = {"test1": "pw1", "test2": "pw2"}
+        # This should be updated to mock a juju config object
+        config = {
+            "pgb_databases": "test-dbs",
+            "pgb_listen_port": "4454",
+            "pgb_listen_address": "4.4.5.4",
+        }
+        pgb_ini = pgb.generate_pgbouncer_ini(users, config)
+        expected_pgb_ini = f"""[databases]
+{config["pgb_databases"]}
+[pgbouncer]
+listen_port = {config["pgb_listen_port"]}
+listen_addr = {config["pgb_listen_address"]}
+auth_type = md5
+auth_file = userlist.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = {",".join(users.keys())}"""
+        self.assertEqual(pgb_ini, expected_pgb_ini)
+
+    def test_generate_userlist(self):
+        users = {"test1": "pw1", "test2": "pw2"}
+        userlist = pgb.generate_userlist(users)
+        expected_userlist = '''"test1" "pw1"
+"test2" "pw2"'''
+        self.assertEqual(userlist, expected_userlist)

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 
-import inspect
 import string
 import unittest
 
@@ -41,29 +40,22 @@ class TestPgb(unittest.TestCase):
         userlist = pgb.generate_userlist(users)
         expected_userlist = '''"test1" "pw1"\n"test2" "pw2"'''
         self.assertEqual(userlist, expected_userlist)
+        self.assertDictEqual(pgb.parse_userlist(expected_userlist), users)
 
     def test_parse_userlist(self):
-        userlist = inspect.cleandoc(
-            '''"testuser" "testpass"
+        with open("tests/unit/data/test_userlist.txt") as f:
+            userlist = f.read()
+            users = pgb.parse_userlist(userlist)
+            expected_users = {
+                "testuser": "testpass",
+                "another_testuser": "anotherpass",
+                "1234": "",
+                "": "",
+            }
+            self.assertDictEqual(users, expected_users)
 
-            "another_testuser" "anotherpass"
-            "1234" ""
-            "" """
-            nospaces
-            t o o m a n y s p a c e s
-            '''
-        )
-        users = pgb.parse_userlist(userlist)
-        expected_users = {
-            "testuser": "testpass",
-            "another_testuser": "anotherpass",
-            "1234": "",
-            "": "",
-        }
-        self.assertDictEqual(users, expected_users)
-
-        # Check that we can run input through a few times without anything getting corrupted.
-        regen_userlist = pgb.generate_userlist(users)
-        regen_users = pgb.parse_userlist(regen_userlist)
-        self.assertNotEqual(regen_userlist, userlist)
-        self.assertDictEqual(users, regen_users)
+            # Check that we can run input through a few times without anything getting corrupted.
+            regen_userlist = pgb.generate_userlist(users)
+            regen_users = pgb.parse_userlist(regen_userlist)
+            self.assertNotEqual(regen_userlist, userlist)
+            self.assertDictEqual(users, regen_users)

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path} 
+lib_path = {toxinidir}/lib/charms/dp_pgbouncer_operator
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 setenv =
@@ -45,7 +45,7 @@ deps =
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
+    codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache


### PR DESCRIPTION
This PR creates a charm library that abstracts some common functions across the pgbouncer charms, which will be published to the /edge channel of the pgbouncer-operator charm on charmhub once implemented. 

The functions this library abstracts are as follows:
- Generating passwords
- Generating config files 

These will obviously expand over time as the charms become more fully featured.

[Jira Ticket](https://warthogs.atlassian.net/browse/DPE-48?atlOrigin=eyJpIjoiZjY4ZmNmZWI5YjhhNDNjMWIzMjE5Mjg2YWNiZDA0YzAiLCJwIjoiaiJ9)