### PR TITLE
DPE-105 Adding pgbouncer.ini Config Management. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+example_pgbouncer.ini

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # TEMPLATE-TODO: change this example to suit your needs.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 type: charm

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # TEMPLATE-TODO: change this example to suit your needs.

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -82,12 +82,10 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
         users: a dictionary of valid usernames and passwords
     """
     parsed_userlist = {}
+    # Each line in userlist can only be two space-separated substrings, wrapped in double quotes.
+    valid_userlist_regex = re.compile(r'^"[^"]*" "[^"]*"$')
     for line in userlist.split("\n"):
-        if (
-            line.strip() == ""
-            or len(line.split(" ")) != 2
-            or len(line.replace('"', "")) != len(line) - 4
-        ):
+        if valid_userlist_regex.fullmatch(line) is None:
             logger.warning("unable to parse line in userlist file - user not imported")
             continue
         # Userlist is formatted '"username" "password"'

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -15,30 +15,17 @@
 """PgBouncer Charm Library.
 
 This charm library provides common pgbouncer-specific features for the pgbouncer machine and
-Kubernetes charms.
+Kubernetes charms, including automatic config management.
 """
 
+import io
 import logging
 import secrets
 import string
+from configparser import ConfigParser
 from typing import Dict
 
-from ops.model import ConfigData
-
 logger = logging.getLogger(__name__)
-
-PGB_INI = """\
-[databases]
-{databases}
-[pgbouncer]
-listen_port = {listen_port}
-listen_addr = {listen_addr}
-auth_type = md5
-auth_file = userlist.txt
-logfile = pgbouncer.log
-pidfile = pgbouncer.pid
-admin_users = {admin_users}
-"""
 
 
 def generate_password() -> str:
@@ -54,34 +41,29 @@ def generate_password() -> str:
     return "".join([secrets.choice(choices) for _ in range(24)])
 
 
-def generate_pgbouncer_ini(users: Dict[str, str], config: ConfigData) -> str:
-    """Generate pgbouncer.ini from config.
-
-    This is a basic stub method, and will be updated in future to generate more complex
-    pgbouncer.ini files in a more sophisticated way.
+def generate_pgbouncer_ini(dbconfig: Dict[str, Dict[str, str]], **kwargs) -> str:
+    """Generate pgbouncer.ini file from the given config options.
 
     Args:
-        users: a dictionary of usernames and passwords
-        config: A juju charm config object
-    Returns:
-        A multiline string defining a valid pgbouncer.ini file
+        dbconfig: database config dictionary
+        kwargs: kwargs following the [pgbouncer config spec](https://pgbouncer.org/config.html).
+            Note that admin_users and stats_users must be passed in as lists of strings, not in
+            their string representation in the .ini file.
     """
-    return PGB_INI.format(
-        databases=config["pgb_databases"],
-        listen_port=config["pgb_listen_port"],
-        listen_addr=config["pgb_listen_address"],
-        admin_users=",".join(users.keys()),
-    )
+    parser = IniParser()
+    cfg_dict = {"databases": dbconfig, "pgbouncer": kwargs}
+    parser.read_dict(cfg_dict)
+    return parser.write_to_string()
 
 
 def generate_userlist(users: Dict[str, str]) -> str:
-    """Generate userlist.txt from the given dictionary of usernames:passwords.
+    """Generate valid userlist.txt from the given dictionary of usernames:passwords.
 
     Args:
         users: a dictionary of usernames and passwords
     Returns:
-        A multiline string, containing each pair of usernames and passwords separated by a
-        space, one pair per line.
+        A multiline string, containing each pair of usernames and passwords in double quotes,
+        separated by a space, one pair per line.
     """
     return "\n".join([f'"{username}" "{password}"' for username, password in users.items()])
 
@@ -100,7 +82,11 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
     """
     parsed_userlist = {}
     for line in userlist.split("\n"):
-        if line.strip() == "" or len(line.split(" ")) != 2:
+        if (
+            line.strip() == ""
+            or len(line.split(" ")) != 2
+            or len(line.replace('"', "")) != len(line) - 4
+        ):
             logger.warning("unable to parse line in userlist file - user not imported")
             continue
         # Userlist is formatted "{username}" "{password}""
@@ -108,3 +94,126 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
         parsed_userlist[username] = password
 
     return parsed_userlist
+
+
+class IniParser(ConfigParser):
+    """A ConfigParser class used to read, write, and edit pgbouncer.ini config files.
+
+    This class also includes parsing and storage for more complex entries in the config file,
+    allowing them to be accessed programmatically.
+    """
+
+    db_section = "databases"
+    pgb_section = "pgbouncer"
+    user_types = ["admin_users", "stats_users"]
+
+    def __init__(self):
+        super().__init__()
+        # Preserve case accurately - without this setting, everything is set to lowercase.
+        self.optionxform = str
+
+        self.dbs = {}
+        self.users = {}
+
+    def _read(self, fp, fpname) -> None:
+        """Reads a pgbouncer.ini file, and uses it to populate this object.
+
+        Overrides ConfigParser._read() method to include pgbouncer-specific parsing of nested
+        values. This method therefore also removes comments from the .ini file.
+
+        The existing parent method parses the .ini file, but database and userlist values in
+        pgbouncer config are more usefully represented as dictionaries and lists respectively, so
+        they can be modified programmatically.
+
+        Args:
+            fp: filepath to be read. Must be iterable.
+            fpname: Source of filepath - for example, <String>
+        """
+        super()._read(fp, fpname)
+
+        # Parse nested dbs from space-separated key=value pairs to a dict.
+        for name, db_config in self[IniParser.db_section].items():
+            db_config_dict = {}
+            for kv_pair in db_config.split(" "):
+                key, value = kv_pair.split("=")
+                db_config_dict[key] = value
+            self.dbs[name] = db_config_dict
+
+        # Parse user lists from comma-separated strings to python lists.
+        for user in IniParser.user_types:
+            try:
+                userlist = self[IniParser.pgb_section][user]
+                self.users[user] = userlist.split(",")
+            except KeyError:
+                # If a user type doesn't exist, that's not a problem.
+                pass
+
+    def _encode_complex_values(self) -> None:
+        """Writes config values from accessible local variables to pgb-readable strings."""
+        # Encode db dicts to writable strings
+        for name, dbconfig in self.dbs.items():
+            # Split each dbconfig value into a space-separated string of key-value pairs
+            self[IniParser.db_section][name] = " ".join(
+                [f"{key}={value}" for key, value in dbconfig.items()]
+            )
+
+        # Encode user lists back to writable strings
+        for userlist in IniParser.user_types:
+            try:
+                self[IniParser.pgb_section][userlist] = ",".join(self.users[userlist])
+            except KeyError:
+                # If a user type doesn't exist, that's not a problem.
+                pass
+
+    def read_dict(self, dictionary, source="<dict>") -> None:
+        """Reads a dictionary and uses it to populate this object.
+
+        Overrides ConfigParser.read_dict() parent method, including some parsing for unique
+        pgbouncer variables.
+
+        Args:
+            dictionary: the dictionary to be read into this object. When forming this dictionary,
+                ensure database config is written as a sub-dictionary, and user config is written
+                as a list, rather than using the pgbouncer config string representation.
+            source: the source of the dict (used primarily for logging)
+        """
+        super().read_dict(dictionary, source)
+
+        self.dbs = dict(dictionary["databases"])
+
+        for user_type in IniParser.user_types:
+            try:
+                if isinstance(dictionary["pgbouncer"][user_type], str):
+                    self.users[user_type] = [dictionary["pgbouncer"][user_type]]
+                else:
+                    self.users[user_type] = list(dictionary["pgbouncer"][user_type])
+            except KeyError:
+                # If a user_type doesn't exist, that's not a problem.
+                pass
+
+        self._encode_complex_values()
+
+    def write(self, fp, space_around_delimiter=True):
+        """Write a pgbouncer file to the given filepath.
+
+        Overrides ConfigParser.write() method to include pgb-specific parsing of nested values.
+
+        Args:
+            fp: Iterable filepath object for
+            space_around_delimiter: whether or not to have spaces around delimiter
+        """
+        # Use ConfigParser.write() to write the file normally.
+        super().write(fp, space_around_delimiter)
+        self._encode_complex_values()
+
+    def write_to_string(self) -> str:
+        """Returns a valid pgbouncer.ini file as a string.
+
+        Returns:
+            str: a string that can be sent to a pgbouncer.ini file.
+        """
+        with io.StringIO() as string_io:
+            self.write(string_io)
+            string_io.seek(0)
+            rtn_string = string_io.read()
+        return rtn_string

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -81,7 +81,7 @@ def parse_userlist(userlist: str) -> Dict[str, str]:
         "juju-admin" "asdf1234"
         '''
     Returns:
-        users: a dictionary of usernames and passwords
+        users: a dictionary of valid usernames and passwords
     """
     parsed_userlist = {}
     for line in userlist.split("\n"):
@@ -181,7 +181,7 @@ class PgbIni(MutableMapping):
 
         for pgb_lst in PgbIni.pgb_list_entries:
             try:
-                self[pgb][pgb_lst] = self._parse_string_to_list(self[pgb][pgb_lst])
+                self[pgb][pgb_lst] = self[pgb][pgb_lst].split(",")
             except KeyError:
                 # user fields are not compulsory, so continue
                 pass
@@ -210,26 +210,6 @@ class PgbIni(MutableMapping):
                 separated with spaces
         """
         return " ".join([f"{key}={value}" for key, value in dictionary.items()])
-
-    def _parse_string_to_list(self, string: str) -> List[str]:
-        """Parses comma-separated strings to a list.
-
-        Args:
-            string: a string containing a comma-separated list
-        Returns:
-            A list of strings
-        """
-        return string.split(",")
-
-    def _parse_list_to_string(self, ls: List[str]) -> str:
-        """Helper function to encode a list into a comma-separated string.
-
-        Args:
-            ls: A list of strings
-        Returns:
-            A string containing a comma-separated list
-        """
-        return ",".join(ls)
 
     def parse_dict(self, input: Dict) -> None:
         """Populates this object from a dictionary.
@@ -261,7 +241,7 @@ class PgbIni(MutableMapping):
                 if isinstance(config_value, dict):
                     output_dict[section][option] = self._parse_dict_to_string(config_value)
                 elif isinstance(config_value, list):
-                    output_dict[section][option] = self._parse_list_to_string(config_value)
+                    output_dict[section][option] = ",".join(config_value)
 
         parser.read_dict(output_dict)
 

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -291,7 +291,7 @@ class PgbIni(MutableMapping):
 
         # Guarantee db names are valid
         for db_id in self[db].keys():
-            db_name = self[db].get("dbname", "")
+            db_name = self[db][db_id].get("dbname", "")
             self._validate_dbname(db_id)
             self._validate_dbname(db_name)
 
@@ -323,4 +323,5 @@ class PgbIni(MutableMapping):
 
     class IniParsingError(ParsingError):
         """Error raised when parsing config fails."""
+
         pass

--- a/lib/charms/dp_pgbouncer_operator/v0/pgb.py
+++ b/lib/charms/dp_pgbouncer_operator/v0/pgb.py
@@ -283,6 +283,10 @@ class PgbIni(MutableMapping):
         Args:
             string: the string to be validated
         """
+        # Check dbnames don't use the reserved "pgbouncer" database name
+        if string == "pgbouncer":
+            raise PgbIni.IniParsingError(source=string)
+
         # Check dbnames are valid characters (alphanumeric and _- )
         search = re.compile(r"[^A-Za-z0-9-_]+").search
         filtered_string = "".join(filter(search, string))

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # For a complete list of supported options, see:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/unit/data/test.ini
+++ b/tests/unit/data/test.ini
@@ -1,0 +1,10 @@
+[databases]
+db = dbname=test_db host=test port=10 user=test password=test client_encoding=test datestyle=test timezone=test pool_size=test connect_query=test
+
+[pgbouncer]
+logfile = test/logfile
+pidfile = test/pidfile
+listen_addr = localhost
+admin_users = Test
+stats_users = Test,stats_test
+

--- a/tests/unit/data/test_bad_db.ini
+++ b/tests/unit/data/test_bad_db.ini
@@ -1,5 +1,5 @@
 [databases]
-test = host=test port=4039 dbname=testdatabase
+te$t = host=test port=4039 dbname=testdatabase
 test2 = host=test2
 
 [pgbouncer]

--- a/tests/unit/data/test_bad_db.ini
+++ b/tests/unit/data/test_bad_db.ini
@@ -1,5 +1,5 @@
 [databases]
-te$t = host=test port=4039 dbname=testdatabase
+test$ = host=test port=4039 dbname=testdatabase
 test2 = host=test2
 
 [pgbouncer]

--- a/tests/unit/data/test_bad_dbname.ini
+++ b/tests/unit/data/test_bad_dbname.ini
@@ -1,5 +1,5 @@
 [databases]
-test = host=test port=4039 dbname=testdata$base
+test = host=test port=4039 dbname=testdatabase$
 test2 = host=test2
 
 [pgbouncer]

--- a/tests/unit/data/test_bad_dbname.ini
+++ b/tests/unit/data/test_bad_dbname.ini
@@ -1,5 +1,5 @@
 [databases]
-test = host=test port=4039 dbname=testdatabase
+test = host=test port=4039 dbname=testdata$base
 test2 = host=test2
 
 [pgbouncer]

--- a/tests/unit/data/test_no_dbs.ini
+++ b/tests/unit/data/test_no_dbs.ini
@@ -1,13 +1,12 @@
-[databases]
-test = host=test port=4039 dbname=testdatabase
-test2 = host=test2
-
 [pgbouncer]
 logfile = test/logfile
 pidfile = test/pidfile
 admin_users = Test
 stats_users = Test,test_stats
 listen_port = 4545
+
+test = host=test port=4039 dbname=testdatabase
+test2 = host=test2
 
 [users]
 Test = pool_mode=session max_user_connections=10

--- a/tests/unit/data/test_no_logfile.ini
+++ b/tests/unit/data/test_no_logfile.ini
@@ -3,7 +3,6 @@ test = host=test port=4039 dbname=testdatabase
 test2 = host=test2
 
 [pgbouncer]
-logfile = test/logfile
 pidfile = test/pidfile
 admin_users = Test
 stats_users = Test,test_stats

--- a/tests/unit/data/test_no_pidfile.ini
+++ b/tests/unit/data/test_no_pidfile.ini
@@ -4,7 +4,6 @@ test2 = host=test2
 
 [pgbouncer]
 logfile = test/logfile
-pidfile = test/pidfile
 admin_users = Test
 stats_users = Test,test_stats
 listen_port = 4545

--- a/tests/unit/data/test_reserved_db.ini
+++ b/tests/unit/data/test_reserved_db.ini
@@ -1,0 +1,14 @@
+[databases]
+pgbouncer = host=test port=4039 dbname=testdatabase
+test2 = host=test2
+
+[pgbouncer]
+logfile = test/logfile
+pidfile = test/pidfile
+admin_users = Test
+stats_users = Test,test_stats
+listen_port = 4545
+
+[users]
+Test = pool_mode=session max_user_connections=10
+

--- a/tests/unit/data/test_userlist.txt
+++ b/tests/unit/data/test_userlist.txt
@@ -2,6 +2,6 @@
 
 "another_testuser" "anotherpass"
 "1234" ""
-"" """
+"" ""
 "no""spaces"
 "too" "many" "spaces"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -50,7 +50,7 @@ class TestCharm(unittest.TestCase):
                     "startup": "enabled",
                     "environment": {"thing": "🎁"},
                 }
-            },
+            }
         }
         # Get the httpbin container from the model
         container = self.harness.model.unit.get_container("httpbin")

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -8,8 +8,8 @@ import pytest
 
 from lib.charms.dp_pgbouncer_operator.v0 import pgb
 
-
 TEST_VALID_INI = "tests/unit/data/test.ini"
+
 
 class TestPgb(unittest.TestCase):
     def test_generate_password(self):
@@ -22,7 +22,11 @@ class TestPgb(unittest.TestCase):
     def test_generate_pgbouncer_ini(self):
         config = {
             "databases": {
-                "test": {"host": "test", "port": "4039", "dbname": "testdatabase",},
+                "test": {
+                    "host": "test",
+                    "port": "4039",
+                    "dbname": "testdatabase",
+                },
                 "test2": {"host": "test2"},
             },
             "pgbouncer": {

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -8,7 +8,8 @@ import pytest
 
 from lib.charms.dp_pgbouncer_operator.v0 import pgb
 
-TEST_VALID_INI = "tests/unit/data/test.ini"
+DATA_DIR = "tests/unit/data"
+TEST_VALID_INI = f"{DATA_DIR}/test.ini"
 
 
 class TestPgb(unittest.TestCase):
@@ -112,35 +113,33 @@ class TestPgb(unittest.TestCase):
         # the constructor.
 
         with open(TEST_VALID_INI, "r") as test_ini:
-            valid_ini = test_ini.read()
-        pgb.PgbIni(valid_ini)
+            pgb.PgbIni(test_ini.read())
 
         # Test parsing fails without necessary config file values
-        with open("tests/unit/data/test_no_dbs.ini", "r") as test_ini_no_dbs:
-            ini_no_dbs = test_ini_no_dbs.read()
-        with pytest.raises(KeyError):
-            pgb.PgbIni(ini_no_dbs)
+        with open(f"{DATA_DIR}/test_no_dbs.ini", "r") as no_dbs:
+            with pytest.raises(KeyError):
+                pgb.PgbIni(no_dbs.read())
 
-        with open("tests/unit/data/test_no_logfile.ini", "r") as test_ini_no_logfile:
-            ini_no_logfile = test_ini_no_logfile.read()
-        with pytest.raises(KeyError):
-            pgb.PgbIni(ini_no_logfile)
+        with open(f"{DATA_DIR}/test_no_logfile.ini", "r") as no_logfile:
+            with pytest.raises(KeyError):
+                pgb.PgbIni(no_logfile.read())
 
-        with open("tests/unit/data/test_no_pidfile.ini", "r") as test_ini_no_pidfile:
-            ini_no_pidfile = test_ini_no_pidfile.read()
-        with pytest.raises(KeyError):
-            pgb.PgbIni(ini_no_pidfile)
+        with open(f"{DATA_DIR}/test_no_pidfile.ini", "r") as no_pidfile:
+            with pytest.raises(KeyError):
+                pgb.PgbIni(no_pidfile.read())
 
         # Test parsing fails when database names are malformed
-        with open("tests/unit/data/test_bad_db.ini", "r") as test_ini_bad_db:
-            ini_bad_db = test_ini_bad_db.read()
-        with pytest.raises(pgb.PgbIni.IniParsingError):
-            pgb.PgbIni(ini_bad_db)
+        with open(f"{DATA_DIR}/test_bad_db.ini", "r") as bad_db:
+            with pytest.raises(pgb.PgbIni.IniParsingError):
+                pgb.PgbIni(bad_db.read())
 
-        with open("tests/unit/data/test_bad_dbname.ini", "r") as test_ini_bad_dbname:
-            ini_bad_dbname = test_ini_bad_dbname.read()
-        with pytest.raises(pgb.PgbIni.IniParsingError):
-            pgb.PgbIni(ini_bad_dbname)
+        with open(f"{DATA_DIR}/test_bad_dbname.ini", "r") as bad_dbname:
+            with pytest.raises(pgb.PgbIni.IniParsingError):
+                pgb.PgbIni(bad_dbname.read())
+
+        with open(f"{DATA_DIR}/test_reserved_db.ini", "r") as reserved_db:
+            with pytest.raises(pgb.PgbIni.IniParsingError):
+                pgb.PgbIni(reserved_db.read())
 
     def test_pgb_ini__validate_dbname(self):
         ini = pgb.PgbIni()

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -16,20 +16,27 @@ class TestPgb(unittest.TestCase):
             assert char in valid_chars
 
     def test_generate_pgbouncer_ini(self):
-        dbs = {
-            "test": {"host": "test", "port": "4039", "dbname": "testdatabase"},
-            "test2": {"host": "test2"},
-        }
-        admin_users = ["test_admin"]
-        stats_users = ["test_admin", "test_stats"]
-        listen_port = "4545"
-        pgbouncer = {
-            "admin_users": admin_users,
-            "stats_users": stats_users,
-            "listen_port": listen_port,
+        config = {
+            "databases": {
+                "test": {"host": "test", "port": "4039", "dbname": "testdatabase"},
+                "test2": {"host": "test2"},
+            },
+            "pgbouncer": {
+                "admin_users": ["test_admin"],
+                "stats_users": ["test_admin", "test_stats"],
+                "listen_port": "4545",
+                "logfile": "/etc/pgbouncer/pgbouncer.log",
+                "pidfile": "/etc/pgbouncer/pgbouncer.pid",
+            },
+            "users": {
+                "test_admin": {
+                    "pool_mode": "session",
+                    "max_user_connections": "10",
+                }
+            },
         }
 
-        generated_ini = pgb.generate_pgbouncer_ini(databases=dbs, pgbouncer=pgbouncer)
+        generated_ini = pgb.generate_pgbouncer_ini(config)
         expected_generated_ini = """[databases]
 test = host=test port=4039 dbname=testdatabase
 test2 = host=test2
@@ -38,6 +45,11 @@ test2 = host=test2
 admin_users = test_admin
 stats_users = test_admin,test_stats
 listen_port = 4545
+logfile = /etc/pgbouncer/pgbouncer.log
+pidfile = /etc/pgbouncer/pgbouncer.pid
+
+[users]
+test_admin = pool_mode=session max_user_connections=10
 
 """
         self.assertEqual(generated_ini, expected_generated_ini)
@@ -76,6 +88,8 @@ test2 = host=test2
 admin_users = test_admin
 stats_users = test_admin,test_stats
 listen_port = 4545
+logfile = /etc/pgbouncer/pgbouncer.log
+pidfile = /etc/pgbouncer/pgbouncer.pid
 
 """
         ini = pgb.PgbIni()
@@ -91,7 +105,8 @@ listen_port = 4545
                 "db2": {"host": "test_host"},
             },
             "pgbouncer": {
-                "logfile": "/etc/pgbouncer/pgb.log",
+                "logfile": "/etc/pgbouncer/pgbouncer.log",
+                "pidfile": "/etc/pgbouncer/pgbouncer.pid",
                 "admin_users": ["test"],
                 "stats_users": ["test", "stats_test"],
             },
@@ -112,6 +127,8 @@ test2 = host=test2
 admin_users = test_admin
 stats_users = test_admin,test_stats
 listen_port = 4545
+logfile = /etc/pgbouncer/pgbouncer.log
+pidfile = /etc/pgbouncer/pgbouncer.pid
 
 """
         ini = pgb.PgbIni()
@@ -120,4 +137,4 @@ listen_port = 4545
         self.assertEqual(input_string, output)
 
     def test_pgb_ini_validate(self):
-        pass
+

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -4,8 +4,12 @@
 import string
 import unittest
 
+import pytest
+
 from lib.charms.dp_pgbouncer_operator.v0 import pgb
 
+
+TEST_VALID_INI = "tests/unit/data/test.ini"
 
 class TestPgb(unittest.TestCase):
     def test_generate_password(self):
@@ -18,18 +22,18 @@ class TestPgb(unittest.TestCase):
     def test_generate_pgbouncer_ini(self):
         config = {
             "databases": {
-                "test": {"host": "test", "port": "4039", "dbname": "testdatabase"},
+                "test": {"host": "test", "port": "4039", "dbname": "testdatabase",},
                 "test2": {"host": "test2"},
             },
             "pgbouncer": {
-                "admin_users": ["test_admin"],
-                "stats_users": ["test_admin", "test_stats"],
+                "logfile": "test/logfile",
+                "pidfile": "test/pidfile",
+                "admin_users": ["Test"],
+                "stats_users": ["Test", "test_stats"],
                 "listen_port": "4545",
-                "logfile": "/etc/pgbouncer/pgbouncer.log",
-                "pidfile": "/etc/pgbouncer/pgbouncer.pid",
             },
             "users": {
-                "test_admin": {
+                "Test": {
                     "pool_mode": "session",
                     "max_user_connections": "10",
                 }
@@ -37,21 +41,8 @@ class TestPgb(unittest.TestCase):
         }
 
         generated_ini = pgb.generate_pgbouncer_ini(config)
-        expected_generated_ini = """[databases]
-test = host=test port=4039 dbname=testdatabase
-test2 = host=test2
-
-[pgbouncer]
-admin_users = test_admin
-stats_users = test_admin,test_stats
-listen_port = 4545
-logfile = /etc/pgbouncer/pgbouncer.log
-pidfile = /etc/pgbouncer/pgbouncer.pid
-
-[users]
-test_admin = pool_mode=session max_user_connections=10
-
-"""
+        with open(TEST_VALID_INI, "r") as test_ini:
+            expected_generated_ini = test_ini.read()
         self.assertEqual(generated_ini, expected_generated_ini)
 
     def test_generate_userlist(self):
@@ -80,23 +71,13 @@ test_admin = pool_mode=session max_user_connections=10
         self.assertDictEqual(users, regen_users)
 
     def test_pgb_ini_parse_string(self):
-        input_string = """[databases]
-test = host=test port=4039 dbname=testdatabase
-test2 = host=test2
-
-[pgbouncer]
-admin_users = test_admin
-stats_users = test_admin,test_stats
-listen_port = 4545
-logfile = /etc/pgbouncer/pgbouncer.log
-pidfile = /etc/pgbouncer/pgbouncer.pid
-
-"""
+        with open(TEST_VALID_INI, "r") as test_ini:
+            input_string = test_ini.read()
         ini = pgb.PgbIni()
         ini.parse_string(input_string)
         expected_dict = {"host": "test", "port": "4039", "dbname": "testdatabase"}
         self.assertDictEqual(ini["databases"]["test"], expected_dict)
-        self.assertEqual(ini["pgbouncer"]["stats_users"], ["test_admin", "test_stats"])
+        self.assertEqual(ini["pgbouncer"]["stats_users"], ["Test", "test_stats"])
 
     def test_pgb_ini_parse_dict(self):
         input_dict = {
@@ -119,22 +100,58 @@ pidfile = /etc/pgbouncer/pgbouncer.pid
         self.assertDictEqual(input_dict, dict(ini))
 
     def test_pgb_ini_render(self):
-        input_string = """[databases]
-test = host=test port=4039 dbname=testdatabase
-test2 = host=test2
-
-[pgbouncer]
-admin_users = test_admin
-stats_users = test_admin,test_stats
-listen_port = 4545
-logfile = /etc/pgbouncer/pgbouncer.log
-pidfile = /etc/pgbouncer/pgbouncer.pid
-
-"""
+        with open(TEST_VALID_INI, "r") as test_ini:
+            input_string = test_ini.read()
         ini = pgb.PgbIni()
         ini.parse_string(input_string)
         output = ini.render()
         self.assertEqual(input_string, output)
 
     def test_pgb_ini_validate(self):
+        ini = pgb.PgbIni()
+        with open(TEST_VALID_INI, "r") as test_ini:
+            valid_ini = test_ini.read()
+        ini.parse_string(valid_ini)
 
+        # Recreate ini to ensure no carryover
+        ini = pgb.PgbIni()
+        with open("tests/unit/data/test_no_dbs.ini", "r") as test_ini_no_dbs:
+            ini_no_dbs = test_ini_no_dbs.read()
+        with pytest.raises(KeyError):
+            ini.parse_string(ini_no_dbs)
+
+        ini = pgb.PgbIni()
+        with open("tests/unit/data/test_no_logfile.ini", "r") as test_ini_no_logfile:
+            ini_no_logfile = test_ini_no_logfile.read()
+        with pytest.raises(KeyError):
+            ini.parse_string(ini_no_logfile)
+
+        ini = pgb.PgbIni()
+        with open("tests/unit/data/test_no_pidfile.ini", "r") as test_ini_no_pidfile:
+            ini_no_pidfile = test_ini_no_pidfile.read()
+        with pytest.raises(KeyError):
+            ini.parse_string(ini_no_pidfile)
+
+        ini = pgb.PgbIni()
+        with open("tests/unit/data/test_bad_db.ini", "r") as test_ini_bad_db:
+            ini_bad_db = test_ini_bad_db.read()
+        with pytest.raises(pgb.PgbIni.IniParsingError):
+            ini.parse_string(ini_bad_db)
+
+        ini = pgb.PgbIni()
+        with open("tests/unit/data/test_bad_dbname.ini", "r") as test_ini_bad_dbname:
+            ini_bad_dbname = test_ini_bad_dbname.read()
+        with pytest.raises(pgb.PgbIni.IniParsingError):
+            ini.parse_string(ini_bad_dbname)
+            ini.validate()
+
+    def test_pgb_ini__validate_dbname(self):
+        ini = pgb.PgbIni()
+        good_dbnames = ["test-_1", 'test"%$"1', 'multiple"$"bad"^"values', '" "']
+        for dbname in good_dbnames:
+            ini._validate_dbname(dbname)
+
+        bad_dbnames = ['"', "%", " ", '"$"test"']
+        for dbname in bad_dbnames:
+            with pytest.raises(pgb.PgbIni.IniParsingError):
+                ini._validate_dbname(dbname)

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -75,10 +75,10 @@ class TestPgb(unittest.TestCase):
         self.assertNotEqual(regen_userlist, userlist)
         self.assertDictEqual(users, regen_users)
 
-    def test_pgb_ini_read_string(self):
+    def test_pgb_config_read_string(self):
         with open(TEST_VALID_INI, "r") as test_ini:
             input_string = test_ini.read()
-        ini = pgb.PgbIni(input_string)
+        ini = pgb.PgbConfig(input_string)
         expected_dict = {
             "databases": {
                 "test": {
@@ -104,7 +104,7 @@ class TestPgb(unittest.TestCase):
         }
         self.assertDictEqual(dict(ini), expected_dict)
 
-    def test_pgb_ini_read_dict(self):
+    def test_pgb_config_read_dict(self):
         input_dict = {
             "databases": {
                 "db1": {"dbname": "test"},
@@ -120,50 +120,50 @@ class TestPgb(unittest.TestCase):
                 "test": {"pool_mode": "session", "max_user_connections": "22"},
             },
         }
-        ini = pgb.PgbIni(input_dict)
+        ini = pgb.PgbConfig(input_dict)
         self.assertDictEqual(input_dict, dict(ini))
 
-    def test_pgb_ini_render(self):
+    def test_pgb_config_render(self):
         with open(TEST_VALID_INI, "r") as test_ini:
             input_string = test_ini.read()
-        output = pgb.PgbIni(input_string).render()
+        output = pgb.PgbConfig(input_string).render()
         self.assertEqual(input_string, output)
 
-    def test_pgb_ini_validate(self):
-        # PgbIni.validate() is called in read_string() and read_dict() methods, which are called in
-        # the constructor.
+    def test_pgb_config_validate(self):
+        # PgbConfig.validate() is called in read_string() and read_dict() methods, which are called
+        # in the constructor.
 
         with open(TEST_VALID_INI, "r") as test_ini:
-            pgb.PgbIni(test_ini.read())
+            pgb.PgbConfig(test_ini.read())
 
         # Test parsing fails without necessary config file values
         with open(f"{DATA_DIR}/test_no_dbs.ini", "r") as no_dbs:
             with pytest.raises(KeyError):
-                pgb.PgbIni(no_dbs.read())
+                pgb.PgbConfig(no_dbs.read())
 
         with open(f"{DATA_DIR}/test_no_logfile.ini", "r") as no_logfile:
             with pytest.raises(KeyError):
-                pgb.PgbIni(no_logfile.read())
+                pgb.PgbConfig(no_logfile.read())
 
         with open(f"{DATA_DIR}/test_no_pidfile.ini", "r") as no_pidfile:
             with pytest.raises(KeyError):
-                pgb.PgbIni(no_pidfile.read())
+                pgb.PgbConfig(no_pidfile.read())
 
         # Test parsing fails when database names are malformed
         with open(f"{DATA_DIR}/test_bad_db.ini", "r") as bad_db:
-            with pytest.raises(pgb.PgbIni.IniParsingError):
-                pgb.PgbIni(bad_db.read())
+            with pytest.raises(pgb.PgbConfig.ConfigParsingError):
+                pgb.PgbConfig(bad_db.read())
 
         with open(f"{DATA_DIR}/test_bad_dbname.ini", "r") as bad_dbname:
-            with pytest.raises(pgb.PgbIni.IniParsingError):
-                pgb.PgbIni(bad_dbname.read())
+            with pytest.raises(pgb.PgbConfig.ConfigParsingError):
+                pgb.PgbConfig(bad_dbname.read())
 
         with open(f"{DATA_DIR}/test_reserved_db.ini", "r") as reserved_db:
-            with pytest.raises(pgb.PgbIni.IniParsingError):
-                pgb.PgbIni(reserved_db.read())
+            with pytest.raises(pgb.PgbConfig.ConfigParsingError):
+                pgb.PgbConfig(reserved_db.read())
 
-    def test_pgb_ini__validate_dbname(self):
-        ini = pgb.PgbIni()
+    def test_pgb_config__validate_dbname(self):
+        ini = pgb.PgbConfig()
         # Valid dbnames include alphanumeric characters and -_ characters. Everything else must
         # be wrapped in double quotes.
         good_dbnames = ["test-_1", 'test"%$"1', 'multiple"$"bad"^"values', '" "', '"\n"', '""']
@@ -172,5 +172,5 @@ class TestPgb(unittest.TestCase):
 
         bad_dbnames = ['"', "%", " ", '"$"test"', "\n"]
         for dbname in bad_dbnames:
-            with pytest.raises(pgb.PgbIni.IniParsingError):
+            with pytest.raises(pgb.PgbConfig.ConfigParsingError):
                 ini._validate_dbname(dbname)

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
 import string
 import unittest
 
@@ -17,23 +16,28 @@ class TestPgb(unittest.TestCase):
             assert char in valid_chars
 
     def test_generate_pgbouncer_ini(self):
-        users = {"test1": "pw1", "test2": "pw2"}
-        # Though this isn't correctly mocking an ops.model.ConfigData object, ConfigData implements
-        # a LazyMapping under the hood that accesses variables in the same way as a dictionary -
-        # they're effectively interchangeable in this context.
-        config = {
-            "pgb_databases": "test-dbs",
-            "pgb_listen_port": "4454",
-            "pgb_listen_address": "4.4.5.4",
+        dbs = {
+            "test": {"host": "test", "port": "4039", "dbname": "testdatabase"},
+            "test2": {"host": "test2"},
         }
-        pgb_ini = pgb.generate_pgbouncer_ini(users, config)
-        expected_pgb_ini = pgb.PGB_INI.format(
-            databases=config["pgb_databases"],
-            listen_port=config["pgb_listen_port"],
-            listen_addr=config["pgb_listen_address"],
-            admin_users=",".join(users.keys()),
+        admin_users = ["test_admin"]
+        stats_users = ["test_admin", "test_stats"]
+        listen_port = "4545"
+
+        generated_ini = pgb.generate_pgbouncer_ini(
+            dbs, admin_users=admin_users, stats_users=stats_users, listen_port=listen_port
         )
-        self.assertEqual(pgb_ini, expected_pgb_ini)
+        expected_generated_ini = """[databases]
+test = host=test port=4039 dbname=testdatabase
+test2 = host=test2
+
+[pgbouncer]
+admin_users = test_admin
+stats_users = test_admin,test_stats
+listen_port = 4545
+
+"""
+        self.assertEqual(generated_ini, expected_generated_ini)
 
     def test_generate_userlist(self):
         users = {"test1": "pw1", "test2": "pw2"}
@@ -45,17 +49,105 @@ class TestPgb(unittest.TestCase):
     def test_parse_userlist(self):
         with open("tests/unit/data/test_userlist.txt") as f:
             userlist = f.read()
-            users = pgb.parse_userlist(userlist)
-            expected_users = {
-                "testuser": "testpass",
-                "another_testuser": "anotherpass",
-                "1234": "",
-                "": "",
-            }
-            self.assertDictEqual(users, expected_users)
+        users = pgb.parse_userlist(userlist)
+        expected_users = {
+            "testuser": "testpass",
+            "another_testuser": "anotherpass",
+            "1234": "",
+            "": "",
+        }
+        self.assertDictEqual(users, expected_users)
 
-            # Check that we can run input through a few times without anything getting corrupted.
-            regen_userlist = pgb.generate_userlist(users)
-            regen_users = pgb.parse_userlist(regen_userlist)
-            self.assertNotEqual(regen_userlist, userlist)
-            self.assertDictEqual(users, regen_users)
+        # Check that we can run input through a few times without anything getting corrupted.
+        regen_userlist = pgb.generate_userlist(users)
+        regen_users = pgb.parse_userlist(regen_userlist)
+        self.assertNotEqual(regen_userlist, userlist)
+        self.assertDictEqual(users, regen_users)
+
+    def test_ini_parser__read(self):
+        test_file = "tests/unit/data/test.ini"
+        parser = pgb.IniParser()
+
+        with open(test_file) as file:
+            parser._read(file, "testfile")
+
+        expected_parser_dbs = {
+            "db": {
+                "dbname": "test_db",
+                "host": "test",
+                "port": "10",
+                "user": "test",
+                "password": "test",
+                "client_encoding": "test",
+                "datestyle": "test",
+                "timezone": "test",
+                "pool_size": "test",
+                "connect_query": "test",
+            }
+        }
+        self.assertDictEqual(parser.dbs, expected_parser_dbs)
+        expected_users = {"admin_users": ["Test"], "stats_users": ["Test", "stats_test"]}
+        self.assertDictEqual(parser.users, expected_users)
+
+        parser_output = parser.write_to_string()
+
+        unmodded_file = ""
+        with open(test_file) as f:
+            for line in f.readlines():
+                # Remove commented lines
+                if line[0] not in ("#", ";"):
+                    unmodded_file += line
+
+        self.assertEqual(parser_output, unmodded_file)
+
+    def test_ini_parser_read_dict(self):
+        parser = pgb.IniParser()
+        parser.read_dict(
+            {
+                "databases": {"db1": {"dbname": "test"}, "db2": {"host": "test_host"}},
+                "pgbouncer": {
+                    "admin_users": ["test"],
+                    "stats_users": ["test", "stats_test"],
+                },
+            }
+        )
+        expected_dbs = {"db1": {"dbname": "test"}, "db2": {"host": "test_host"}}
+        expected_users = {
+            "admin_users": ["test"],
+            "stats_users": ["test", "stats_test"],
+        }
+        self.assertDictEqual(parser.dbs, expected_dbs)
+        self.assertDictEqual(parser.users, expected_users)
+
+    def test_ini_parser_case_sensitive(self):
+        parser = pgb.IniParser()
+        self.assertEqual(parser.optionxform, str)
+        parser.read_dict(
+            {
+                "databases": {
+                    "db": {
+                        "dbname": "test",
+                        "port": "555",
+                    },
+                },
+                "pgbouncer": {"admin_users": "CAPSTEST"},
+            }
+        )
+        self.assertEqual(parser["pgbouncer"]["admin_users"], "CAPSTEST")
+
+    def test_ini_parser_write_to_string(self):
+        test_file = "tests/unit/data/test.ini"
+        parser = pgb.IniParser()
+
+        with open(test_file) as file:
+            parser.read_file(file)
+        parser_output = parser.write_to_string()
+
+        unmodded_file = ""
+        with open(test_file) as f:
+            for line in f.readlines():
+                # Remove commented lines
+                if line[0] not in ("#", ";"):
+                    unmodded_file += line
+
+        self.assertEqual(parser_output, unmodded_file)

--- a/tests/unit/test_pgb.py
+++ b/tests/unit/test_pgb.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import string
@@ -79,9 +79,30 @@ class TestPgb(unittest.TestCase):
         with open(TEST_VALID_INI, "r") as test_ini:
             input_string = test_ini.read()
         ini = pgb.PgbIni(input_string)
-        expected_dict = {"host": "test", "port": "4039", "dbname": "testdatabase"}
-        self.assertDictEqual(ini["databases"]["test"], expected_dict)
-        self.assertEqual(ini["pgbouncer"]["stats_users"], ["Test", "test_stats"])
+        expected_dict = {
+            "databases": {
+                "test": {
+                    "host": "test",
+                    "port": "4039",
+                    "dbname": "testdatabase",
+                },
+                "test2": {"host": "test2"},
+            },
+            "pgbouncer": {
+                "logfile": "test/logfile",
+                "pidfile": "test/pidfile",
+                "admin_users": ["Test"],
+                "stats_users": ["Test", "test_stats"],
+                "listen_port": "4545",
+            },
+            "users": {
+                "Test": {
+                    "pool_mode": "session",
+                    "max_user_connections": "10",
+                }
+            },
+        }
+        self.assertDictEqual(dict(ini), expected_dict)
 
     def test_pgb_ini_read_dict(self):
         input_dict = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
[Jira Ticket](https://warthogs.atlassian.net/browse/DPE-105?atlOrigin=eyJpIjoiZmVkZjk3MTcxYzM0NGJkMDg1NTU0NTQ5YjY1YWVlNWIiLCJwIjoiaiJ9)

This PR implements a class in the pgb charm library that can handle pgbouncer.ini config files, including parsing, editing, and writing. The existing implementation is a placeholder that implements the bare minimum for the pgbouncer application to come online, whereas the proposed implementation is capable of making use of the entire [pgbouncer config spec](https://www.pgbouncer.org/config.html). 

This class implements a mutablemapping that's copied from a [ConfigParser](https://docs.python.org/3/library/configparser.html) object, allowing config options to be accessed and modified dictionary-style, as well as providing some basic validation. The reason this doesn't just inherit from a ConfigParser is that it only uses strings, and therefore can't represent some of the config values that are better represented as dicts or lists.

Changelog: 
- Added PgbIni class
  - Added the ability to parse strings that represent pgbouncer.ini files
  - Added the ability to pass in pgbouncer config as a dictionary 
- Replaced placeholder pgbouncer.ini generation