### PR TITLE
DPE-107 Add Pr Template 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,14 @@
-# Issue
+## Issue
 <!-- What issue is this PR trying to solve? -->
 
-
-# Solution
+## Solution
 <!-- A summary of the solution addressing the above issue. -->
 
-
-# Context
+## Context
 <!-- Necessary details to understand the proposed changes. -->
 
-
-# Release Notes
+## Release Notes
 <!-- A digestable summary of the changes in this PR. -->
 
-
-# Testing
+## Testing
 <!-- A summary of how this PR has been tested. -->
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Issue
+<!-- What issue is this PR trying to solve? -->
+
+
+# Solution
+<!-- A summary of the solution addressing the above issue. -->
+
+
+# Context
+<!-- Necessary details to understand the proposed changes. -->
+
+
+# Release Notes
+<!-- A digestable summary of the changes in this PR. -->
+
+
+# Testing
+<!-- A summary of how this PR has been tested. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ## Issue
-<!-- What issue is this PR trying to solve? -->
+<!-- What does this PR solve? Include a Jira ticket.  -->
 
 ## Solution
-<!-- A summary of the solution addressing the above issue. -->
+<!-- A summary of the proposed solution to the above issue. -->
 
 ## Context
 <!-- Necessary details to understand the proposed changes. -->
 
 ## Release Notes
-<!-- A digestable summary of the changes in this PR. -->
+<!-- A simple bullet-point summary of the changes in this PR. -->
 
 ## Testing
-<!-- A summary of how this PR has been tested. -->
+<!-- A summary of how this PR has been tested, including automated testing. -->


### PR DESCRIPTION
## Issue
This repo has no PR templates, making it easy for PR authors to forget necessary information such as context or testing. 

[JIRA ticket](https://warthogs.atlassian.net/browse/DPE-107?atlOrigin=eyJpIjoiYWUyMmJiNTZiNTc2NDI1NGE5ZWYzNzI1YmMxNTdlMTAiLCJwIjoiaiJ9)

## Solution
Add a PR template that adds useful sections to PRs moving forward. 

## Context
This template differs slightly from [Shayan's proposed template](https://github.com/canonical/mysql-k8s-operator/pull/70). My reasoning for changing the template in this repo without propagating my feedback to the original PR is as follows:
- I want to start using PR templates as soon as possible. It's easy to endlessly discuss process, but we won't fully understand what's useful information and what's a chore until we try it. 
- I'd prefer for these standards to be more flexible - for example, a testing section is necessary for code changes, but unnecessary for documentation changes. I'd like for PR authors to change these templates at their discretion. 

The plan, therefore, is to implement a minimal template that doesn't enforce box-ticking and unnecessary explanations, while pushing PR authors to include information necessary for reviewers. 
