### PR TITLE
updated readonly endpoints

### DIFF
--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -84,7 +84,7 @@ Some example relation data is below. All values are examples, generated in a run
 └──────────────────┴─────────────────────┴─────────────────────────────────────────────────────────────────┘
 """  # noqa: W505
 import logging
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
 from charms.pgbouncer_k8s.v0 import pgb
 from charms.postgresql_k8s.v0.postgresql import (
@@ -368,12 +368,13 @@ class DbProvides(Object):
             "auth_user": self.charm.backend.auth_user,
         }
 
-        read_only_endpoint = self._get_read_only_endpoint()
-        if read_only_endpoint:
+        read_only_endpoints = self._get_read_only_endpoints()
+        if read_only_endpoints:
+            endpoint_ips = [endpoint.split(":")[0] for endpoint in read_only_endpoints]
             cfg["databases"][f"{database}_standby"] = {
-                "host": read_only_endpoint.split(":")[0],
+                "host": ",".join(endpoint_ips),
                 "dbname": database,
-                "port": read_only_endpoint.split(":")[1],
+                "port": read_only_endpoints[0].split(":")[1],
                 "auth_user": self.charm.backend.auth_user,
             }
         else:
@@ -493,16 +494,16 @@ class DbProvides(Object):
         model_name = self.model.name
         return f"{app_name}_user_{relation_id}_{model_name}".replace("-", "_")
 
-    def _get_read_only_endpoint(self):
-        """Get a read-only-endpoint from backend relation.
+    def _get_read_only_endpoints(self) -> List[str]:
+        """Get a list of read-only-endpoint from backend relation.
 
         Though multiple readonly endpoints can be provided by the new backend relation, only one
         can be consumed by this legacy relation.
         """
         read_only_endpoints = self.charm.backend.postgres_databag.get("read-only-endpoints")
         if read_only_endpoints is None or len(read_only_endpoints) == 0:
-            return None
-        return read_only_endpoints.split(",")[0]
+            return []
+        return read_only_endpoints.split(",")
 
     def _get_state(self) -> str:
         """Gets the given state for this unit.

--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -233,11 +233,11 @@ class TestDb(unittest.TestCase):
         new_callable=PropertyMock,
         return_value={},
     )
-    @patch("relations.db.DbProvides._get_read_only_endpoint", return_value=None)
+    @patch("relations.db.DbProvides._get_read_only_endpoints", return_value=None)
     @patch("charm.PgBouncerCharm.read_pgb_config", return_value=PgbConfig(DEFAULT_CONFIG))
     @patch("charm.PgBouncerCharm.render_pgb_config")
     def test_update_postgres_endpoints(
-        self, _render_cfg, _read_cfg, _read_only_endpoint, _pg_databag, _get_databags
+        self, _render_cfg, _read_cfg, _read_only_endpoints, _pg_databag, _get_databags
     ):
         database = "test_db"
         _get_databags.return_value[0] = {"database": database}
@@ -252,7 +252,7 @@ class TestDb(unittest.TestCase):
         assert f"{database}_standby" not in cfg["databases"].keys()
         assert PG not in cfg["databases"].keys()
         _render_cfg.assert_called_with(cfg, reload_pgbouncer=reload_pgbouncer)
-        _read_only_endpoint.return_value = "readonly:endpoint"
+        _read_only_endpoints.return_value = ["readonly:endpoint"]
 
         self.db_relation.update_postgres_endpoints(relation, reload_pgbouncer)
         assert database in cfg["databases"].keys()


### PR DESCRIPTION
## Proposal
When pointing to readonly endpoints, pgbouncer would just pick a random standby node and point to that. This PR updates the standby node in the pgb config to point to all postgres standby nodes, switching between them in a round robin. 

## Context
[docs](https://www.pgbouncer.org/config.html#host)

## Testing
- Unit tests have been updated, all integration tests currently pass 
