### PR TITLE
Fixed typing errors in ops v1.5.3

### DIFF
--- a/lib/charms/pgbouncer_k8s/v0/pgb.py
+++ b/lib/charms/pgbouncer_k8s/v0/pgb.py
@@ -78,7 +78,7 @@ DEFAULT_CONFIG = {
     "databases": {},
     "pgbouncer": {
         "listen_addr": "*",
-        "listen_port": "6432",
+        "listen_port": 6432,
         "logfile": f"{PGB_DIR}/pgbouncer.log",
         "pidfile": f"{PGB_DIR}/pgbouncer.pid",
         "admin_users": set(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ops >= 1.5.2
+ops >= 1.5.3
 pgconnstr==1.0.1
 tenacity==8.0.1

--- a/tests/unit/relations/test_backend_database.py
+++ b/tests/unit/relations/test_backend_database.py
@@ -32,7 +32,6 @@ class TestBackendDatabaseRelation(unittest.TestCase):
         # Define a backend relation
         self.rel_id = self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.add_relation_unit(self.rel_id, "postgres/0")
-        self.harness.add_relation_unit(self.rel_id, self.unit)
 
         # Define a peer relation
         self.peers_rel_id = self.harness.add_relation(PEER_RELATION_NAME, "pgbouncer/0")

--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -45,22 +45,19 @@ class TestDb(unittest.TestCase):
         # Define a backend relation
         self.backend_rel_id = self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.add_relation_unit(self.backend_rel_id, "postgres/0")
-        self.harness.add_relation_unit(self.backend_rel_id, self.unit)
 
         # Define a db relation
         self.db_rel_id = self.harness.add_relation(DB_RELATION_NAME, "client_app")
-        self.harness.add_relation_unit(self.db_rel_id, "client/0")
-        self.harness.add_relation_unit(self.db_rel_id, self.unit)
+        self.harness.add_relation_unit(self.db_rel_id, "client_app/0")
 
         # Define a db-admin relation
         self.db_admin_rel_id = self.harness.add_relation(
-            DB_ADMIN_RELATION_NAME, "admin_client_app"
+            DB_ADMIN_RELATION_NAME, "admin_client"
         )
         self.harness.add_relation_unit(self.db_admin_rel_id, "admin_client/0")
-        self.harness.add_relation_unit(self.db_admin_rel_id, self.unit)
 
         # Define a peer relation
-        self.peers_rel_id = self.harness.add_relation(PEER_RELATION_NAME, "pgbouncer/0")
+        self.peers_rel_id = self.harness.add_relation(PEER_RELATION_NAME, "pgbouncer")
         self.harness.add_relation_unit(self.peers_rel_id, self.unit)
 
     def test_correct_admin_perms_set_in_constructor(self):

--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -51,9 +51,7 @@ class TestDb(unittest.TestCase):
         self.harness.add_relation_unit(self.db_rel_id, "client_app/0")
 
         # Define a db-admin relation
-        self.db_admin_rel_id = self.harness.add_relation(
-            DB_ADMIN_RELATION_NAME, "admin_client"
-        )
+        self.db_admin_rel_id = self.harness.add_relation(DB_ADMIN_RELATION_NAME, "admin_client")
         self.harness.add_relation_unit(self.db_admin_rel_id, "admin_client/0")
 
         # Define a peer relation

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -170,14 +170,14 @@ class TestCharm(unittest.TestCase):
             pgb_instances=mock_cores,
         )
 
-        test_config["pgbouncer"]["listen_port"] = "6464"
+        test_config["pgbouncer"]["listen_port"] = 6464
 
         # set config to include pool_mode and max_db_connections
         self.harness.update_config(
             {
                 "pool_mode": "transaction",
                 "max_db_connections": max_db_connections,
-                "listen_port": "6464",
+                "listen_port": 6464,
             }
         )
 


### PR DESCRIPTION
## Proposal
Ops v1.5.3 adds better typing support. This happens to break a few of my existing tests that weren't correctly typed. 

## Release Notes
- Fix unit tests broken by ops v1.5.3. 
