### PR TITLE
Revert "updated readonly endpoints"

### DIFF
--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -228,11 +228,11 @@ class TestDb(unittest.TestCase):
         new_callable=PropertyMock,
         return_value={},
     )
-    @patch("relations.db.DbProvides._get_read_only_endpoints", return_value=None)
+    @patch("relations.db.DbProvides._get_read_only_endpoint", return_value=None)
     @patch("charm.PgBouncerCharm.read_pgb_config", return_value=PgbConfig(DEFAULT_CONFIG))
     @patch("charm.PgBouncerCharm.render_pgb_config")
     def test_update_postgres_endpoints(
-        self, _render_cfg, _read_cfg, _read_only_endpoints, _pg_databag, _get_databags
+        self, _render_cfg, _read_cfg, _read_only_endpoint, _pg_databag, _get_databags
     ):
         database = "test_db"
         _get_databags.return_value[0] = {"database": database}
@@ -247,7 +247,7 @@ class TestDb(unittest.TestCase):
         assert f"{database}_standby" not in cfg["databases"].keys()
         assert PG not in cfg["databases"].keys()
         _render_cfg.assert_called_with(cfg, reload_pgbouncer=reload_pgbouncer)
-        _read_only_endpoints.return_value = ["readonly:endpoint"]
+        _read_only_endpoint.return_value = "readonly:endpoint"
 
         self.db_relation.update_postgres_endpoints(relation, reload_pgbouncer)
         assert database in cfg["databases"].keys()


### PR DESCRIPTION
## Proposal
Reverts canonical/pgbouncer-operator#24

## Context
The feature that this PR relies on is only implemented in pgbouncer version 1.17. This'll be re-implemented once the pgbouncer snap is available