### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
 
   integration-standalone:
     name: Integration tests for standalone charm
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +44,9 @@ jobs:
 
   integration-backend:
     name: Integration tests for backend relation
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,6 +61,9 @@ jobs:
 
   integration-legacy-relations:
     name: Integration tests for legacy relations
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -70,6 +79,9 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling pgbouncer (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-standalone:
     name: Integration tests for standalone charm
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +62,10 @@ jobs:
 
   integration-backend:
     name: Integration tests for backend relation
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,6 +81,10 @@ jobs:
 
   integration-legacy-relations:
     name: Integration tests for legacy relations
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -87,6 +99,10 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling pgbouncer (microk8s)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -109,7 +125,6 @@ jobs:
       - integration-backend
       - integration-legacy-relations
       - integration-scaling
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.

## Proposal
Optimize costs for tests.

## Context
Trivial PR to reorder the tests execution (heavy integration tests are the last in queue).

## Release Notes
Run integration tests for passed lint/unit tests only

## Testing
Tested by GitHub actions only. :-)
