### PR TITLE
systemd socket activation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@ options:
     description: |
       The port on which pgbouncer listens for traffic. Corresponds to
       listen_port in pgbouncer config.
+
+      Updating this will cause service interruption.
     type: int
 
   pool_mode:

--- a/lib/charms/pgbouncer_k8s/v0/pgb.py
+++ b/lib/charms/pgbouncer_k8s/v0/pgb.py
@@ -89,6 +89,7 @@ DEFAULT_CONFIG = {
         "max_client_conn": "10000",
         "ignore_startup_parameters": "extra_float_digits",
         "server_tls_sslmode": "prefer",
+        "so_reuseport": "1",
         "unix_socket_dir": PGB_DIR,
     },
 }

--- a/lib/charms/pgbouncer_k8s/v0/pgb.py
+++ b/lib/charms/pgbouncer_k8s/v0/pgb.py
@@ -89,7 +89,6 @@ DEFAULT_CONFIG = {
         "max_client_conn": "10000",
         "ignore_startup_parameters": "extra_float_digits",
         "server_tls_sslmode": "prefer",
-        "so_reuseport": "1",
         "unix_socket_dir": PGB_DIR,
     },
 }

--- a/src/charm.py
+++ b/src/charm.py
@@ -73,12 +73,6 @@ class PgBouncerCharm(CharmBase):
         os.mkdir(PGB_DIR, 0o700)
         os.chown(PGB_DIR, pg_user.pw_uid, pg_user.pw_gid)
 
-        # Make a directory for each service to store logs, configs, pidfiles and sockets.
-        # TODO this can be removed once socket activation is implemented (JIRA-218)
-        for service_id in self.service_ids:
-            os.mkdir(f"{INSTANCE_PATH}{service_id}", 0o700)
-            os.chown(f"{INSTANCE_PATH}{service_id}", pg_user.pw_uid, pg_user.pw_gid)
-
         # Initialise pgbouncer.ini config files from defaults set in charm lib and current config.
         # We'll add basic configs for now even if this unit isn't a leader, so systemd doesn't
         # throw a fit.

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,22 +219,18 @@ class PgBouncerCharm(CharmBase):
 
         self.peers.update_cfg(config)
 
-        # create a copy of the config so the original reference is unchanged.
-        primary_config = deepcopy(config)
-
         # Render primary config. This config is the only copy that the charm reads from to create
         # PgbConfig objects, and is modified below to implement individual services.
-        self._render_pgb_config(pgb.PgbConfig(primary_config), config_path=INI_PATH)
+        self._render_pgb_config(config, config_path=INI_PATH)
 
         # Modify & render config files for each service instance
         for service_id in self.service_ids:
             instance_dir = f"{INSTANCE_PATH}{service_id}"  # Generated in on_install hook
 
-            primary_config[PGB]["unix_socket_dir"] = instance_dir
-            primary_config[PGB]["logfile"] = f"{instance_dir}/pgbouncer.log"
-            primary_config[PGB]["pidfile"] = f"{instance_dir}/pgbouncer.pid"
+            config[PGB]["logfile"] = f"{instance_dir}/pgbouncer.log"
+            config[PGB]["pidfile"] = f"{instance_dir}/pgbouncer.pid"
 
-            self._render_pgb_config(primary_config, config_path=f"{instance_dir}/pgbouncer.ini")
+            self._render_pgb_config(config, config_path=f"{instance_dir}/pgbouncer.ini")
 
         if reload_pgbouncer:
             self.reload_pgbouncer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,8 +28,6 @@ from relations.db import DbProvides
 from relations.peers import Peers
 from relations.pgbouncer_provider import PgBouncerProvider
 
-from configparser import ConfigParser, ParsingError
-
 logger = logging.getLogger(__name__)
 
 INSTANCE_PATH = f"{PGB_DIR}/instance_"
@@ -285,7 +283,7 @@ class PgBouncerCharm(CharmBase):
         """Updates pgbouncer systemd socket, and reloads systemd."""
         with open("src/pgbouncer@.socket", "r") as file:
             socket_cfg = file.read()
-        socket_cfg.replace("PORT_PLACEHOLDER", self.config["listen_port"])
+        socket_cfg.replace("PORT_PLACEHOLDER", str(self.config["listen_port"]))
         self.render_file("/etc/systemd/system/pgbouncer@.socket", socket_cfg, perms=0o664)
         systemd.daemon_reload()
 

--- a/src/pgbouncer@.service
+++ b/src/pgbouncer@.service
@@ -4,11 +4,11 @@ After=network.target
 Requires=pgbouncer@%i.socket
 
 [Service]
-Type=simple
+Type=notify
 User=postgres
 # -R flag lets separate pgbouncer instances reuse sockets from previous instances, so on restart
 # they'll reuse the same sockets, preserving connections.
-ExecStart=/sbin/pgbouncer -R /var/lib/postgresql/pgbouncer/pgbouncer.ini
+ExecStart=/sbin/pgbouncer /var/lib/postgresql/pgbouncer/pgbouncer.ini
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 Restart=on-failure

--- a/src/pgbouncer@.service
+++ b/src/pgbouncer@.service
@@ -8,7 +8,7 @@ Type=simple
 User=postgres
 # -R flag lets separate pgbouncer instances reuse sockets from previous instances, so on restart
 # they'll reuse the same sockets, preserving connections.
-ExecStart=/sbin/pgbouncer -R /var/lib/postgresql/pgbouncer/instance_%i/pgbouncer.ini
+ExecStart=/sbin/pgbouncer -R /var/lib/postgresql/pgbouncer/pgbouncer.ini
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 Restart=on-failure

--- a/src/pgbouncer@.service
+++ b/src/pgbouncer@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=connection pooler for postgresql (%i)
 After=network.target
+Requires=pgbouncer@%i.socket
 
 [Service]
 Type=simple

--- a/src/pgbouncer@.service
+++ b/src/pgbouncer@.service
@@ -4,11 +4,11 @@ After=network.target
 Requires=pgbouncer@%i.socket
 
 [Service]
-Type=notify
+Type=simple
 User=postgres
 # -R flag lets separate pgbouncer instances reuse sockets from previous instances, so on restart
 # they'll reuse the same sockets, preserving connections.
-ExecStart=/sbin/pgbouncer /var/lib/postgresql/pgbouncer/pgbouncer.ini
+ExecStart=/sbin/pgbouncer -R /var/lib/postgresql/pgbouncer/pgbouncer.ini
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 Restart=on-failure

--- a/src/pgbouncer@.socket
+++ b/src/pgbouncer@.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=sockets for PgBouncer
+
+[Socket]
+ListenStream=PORT_PLACEHOLDER
+ListenStream=%i
+ListenStream=/tmp/.s.PGSQL.%i
+
+ReusePort=true
+
+[Install]
+WantedBy=sockets.target

--- a/src/pgbouncer@.socket
+++ b/src/pgbouncer@.socket
@@ -3,8 +3,7 @@ Description=sockets for PgBouncer
 
 [Socket]
 ListenStream=PORT_PLACEHOLDER
-ListenStream=%i
-ListenStream=/tmp/.s.PGSQL.%i
+ListenStream=/var/lib/postgresql/pgbouncer/.s.PGSQL.PORT_PLACEHOLDER
 
 ReusePort=true
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -68,7 +68,7 @@ async def test_change_config(ops_test: OpsTest):
     # Validating service config files are correctly written is handled by render_pgb_config and its
     # tests, but we need to make sure they at least exist in the right places.
     for service_id in range(cores):
-        path = f"{PGB_DIR}/instance_{service_id}/pgbouncer.ini"
+        path = f"{PGB_DIR}/pgbouncer.ini"
         service_cfg = await helpers.get_cfg(ops_test, unit.name, path=path)
         assert service_cfg is not f"cat: {path}: No such file or directory"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -65,12 +65,11 @@ async def test_change_config(ops_test: OpsTest):
 
     assert existing_cfg.render() == primary_cfg.render()
 
-    # Validating service config files are correctly written is handled by render_pgb_config and its
-    # tests, but we need to make sure they at least exist in the right places.
-    for service_id in range(cores):
-        path = f"{PGB_DIR}/pgbouncer.ini"
-        service_cfg = await helpers.get_cfg(ops_test, unit.name, path=path)
-        assert service_cfg is not f"cat: {path}: No such file or directory"
+    # Validating service config file is correctly written is handled by render_pgb_config and its
+    # tests, but we need to make sure it at least exists in the right places.
+    path = f"{PGB_DIR}/pgbouncer.ini"
+    service_cfg = await helpers.get_cfg(ops_test, unit.name, path=path)
+    assert service_cfg is not f"cat: {path}: No such file or directory"
 
 
 @pytest.mark.standalone

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -153,9 +153,10 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.PgBouncerCharm.read_pgb_config", return_value=pgb.PgbConfig(DEFAULT_CFG))
     @patch("charm.PgBouncerCharm.render_pgb_config")
+    @patch("charm.PgBouncerCharm.update_systemd_socket")
     @patch("relations.peers.Peers.app_databag", new_callable=PropertyMock)
     @patch_network_get(private_address="1.1.1.1")
-    def test_on_config_changed(self, _app_databag, _render, _read):
+    def test_on_config_changed(self, _app_databag, _update_socket, _render, _read):
         self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.set_leader()
         mock_cores = 1
@@ -182,6 +183,7 @@ class TestCharm(unittest.TestCase):
         )
 
         _read.assert_called_once()
+        _update_socket.assert_called_once()
         # _read.return_value is modified on config update, but the object reference is the same.
         _render.assert_called_with(_read.return_value, reload_pgbouncer=True)
         self.assertDictEqual(dict(_read.return_value), dict(test_config))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -61,10 +61,6 @@ class TestCharm(unittest.TestCase):
         _mkdir.assert_any_call(PGB_DIR, 0o700)
         _chown.assert_any_call(PGB_DIR, 1100, 120)
 
-        for service_id in self.charm.service_ids:
-            _mkdir.assert_any_call(f"{PGB_DIR}/instance_{service_id}", 0o700)
-            _chown.assert_any_call(f"{PGB_DIR}/instance_{service_id}", 1100, 120)
-
         # Check config files are rendered, including correct permissions
         initial_cfg = pgb.PgbConfig(DEFAULT_CFG)
         _render_configs.assert_called_once_with(initial_cfg)


### PR DESCRIPTION
## Proposal
Adds [systemd socket activation](https://www.2ndquadrant.com/en/blog/running-multiple-pgbouncer-instances-with-systemd/)

## Context
Previously, we were having to use some workarounds to reuse ports across pgbouncer instances, where we were duplicating the config for each systemd instance of pgbouncer. By using systemd sockets and pgbouncer>=1.14, we no longer have to do this.

## Testing
Integration tests are passing, no new testing added. 
