### PR TITLE
Fix relatior error when extra user roles field has no value

### DIFF
--- a/src/relations/pgbouncer_provider.py
+++ b/src/relations/pgbouncer_provider.py
@@ -103,7 +103,7 @@ class PgBouncerProvider(Object):
 
         # Retrieve the database name and extra user roles using the charm library.
         databases = event.database
-        extra_user_roles = event.extra_user_roles
+        extra_user_roles = event.extra_user_roles or ""
         rel_id = event.relation.id
 
         # Creates the user and the database for this specific relation.

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -29,6 +29,7 @@ from tests.integration.relations.pgbouncer_provider.helpers import (
 logger = logging.getLogger(__name__)
 
 CLIENT_APP_NAME = "application"
+DATA_INTEGRATOR_APP_NAME = "data-integrator"
 CLIENT_UNIT_NAME = f"{CLIENT_APP_NAME}/0"
 TEST_DBNAME = "application_first_database"
 ANOTHER_APPLICATION_APP_NAME = "another-application"
@@ -424,3 +425,17 @@ async def test_relation_broken(ops_test: OpsTest):
     cfg = await get_cfg(ops_test, pgb_unit_name)
     assert "first-database" not in cfg["databases"].keys()
     assert "first-database_readonly" not in cfg["databases"].keys()
+
+
+@pytest.mark.client_relation
+async def test_relation_with_data_integrator(ops_test: OpsTest):
+    """Test that the charm can be related to the data integrator without extra user roles."""
+    config = {"database-name": "test-database"}
+    await ops_test.model.deploy(
+        DATA_INTEGRATOR_APP_NAME,
+        channel="edge",
+        config=config,
+    )
+    await ops_test.model.add_relation(f"{PGB}:database", DATA_INTEGRATOR_APP_NAME)
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active")

--- a/tests/integration/relations/test_peers.py
+++ b/tests/integration/relations/test_peers.py
@@ -92,7 +92,6 @@ async def test_scaling(ops_test: OpsTest):
     # Ensure the initial number of units in the application.
     initial_scale = 4
     async with ops_test.fast_forward():
-
         await scale_application(ops_test, PGB, initial_scale)
         await asyncio.gather(
             ops_test.model.wait_for_idle(apps=[MAILMAN], status="active", timeout=600),


### PR DESCRIPTION
## Proposal
Jira ticket: [DPE-1234](https://warthogs.atlassian.net/browse/DPE-1234)

The PgBouncer charm failed when the other charm haven't requested any extra user roles (so the field is None and due to that it cannot be iteraded). It was happening when relating to the data-integrator and specifying only it's required config (database name), but it would happen with any other charm that don't request extra user roles through the relation.

Fixed that by using an empty value instead of none, to be consistent with the check the PgBouncer charm make.

## Context
It's the same that was implemented on https://github.com/canonical/pgbouncer-k8s-operator/pull/36.

## Release Notes
Fix relatior error when extra user roles field has no value.

## Testing
Added a test where the charm is related to the data integrator.


[DPE-1234]: https://warthogs.atlassian.net/browse/DPE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ