### PR TITLE
Update flake8 and libjuju

### DIFF
--- a/tests/integration/relations/test_peers.py
+++ b/tests/integration/relations/test_peers.py
@@ -92,7 +92,6 @@ async def test_scaling(ops_test: OpsTest):
     # Ensure the initial number of units in the application.
     initial_scale = 4
     async with ops_test.fast_forward():
-
         await scale_application(ops_test, PGB, initial_scale)
         await asyncio.gather(
             ops_test.model.wait_for_idle(apps=[MAILMAN], status="active", timeout=600),

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -68,7 +68,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     pytest-operator
     psycopg2-binary
     mailmanclient
@@ -81,7 +81,7 @@ commands =
 description = Run all integration tests
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     pytest-operator
     psycopg2-binary
     mailmanclient
@@ -94,7 +94,7 @@ commands =
 description = Run integration tests marked dev
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient
@@ -107,7 +107,7 @@ commands =
 description = Run integration tests for standalone charm function
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient
@@ -120,7 +120,7 @@ commands =
 description = Run integration tests for backend relation
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient
@@ -134,7 +134,7 @@ commands =
 description = Run integration tests for modern client relations
 deps =
     pytest
-    juju==2.9.11
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient
@@ -148,7 +148,7 @@ commands =
 description = Run integration tests for legacy relations
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient
@@ -162,7 +162,7 @@ commands =
 description = Run integration tests for scaling pgbouncer
 deps =
     pytest
-    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    juju~=2.9.0 # Latest juju 2
     psycopg2-binary
     pytest-operator
     mailmanclient


### PR DESCRIPTION
## Proposal
* [DPE-1162](https://warthogs.atlassian.net/browse/DPE-1162)
* Update libjuju to latest v2
* Unpin flake8

## Context

## Release Notes

## Testing


[DPE-1162]: https://warthogs.atlassian.net/browse/DPE-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ