### PR TITLE
Revive pgb

### DIFF
--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -125,12 +125,12 @@ class BackendDatabaseRequires(Object):
             return
 
         plaintext_password = pgb.generate_password()
+        hashed_password = pgb.get_hashed_password(self.auth_user, plaintext_password)
         # create authentication user on postgres database, so we can authenticate other users
         # later on
-        self.postgres.create_user(self.auth_user, plaintext_password, admin=True)
+        self.postgres.create_user(self.auth_user, hashed_password, admin=True)
         self.initialise_auth_function([self.database.database, PG])
 
-        hashed_password = pgb.get_hashed_password(self.auth_user, plaintext_password)
         self.charm.render_auth_file(f'"{self.auth_user}" "{hashed_password}"')
 
         cfg = self.charm.read_pgb_config()

--- a/tests/unit/relations/test_backend_database.py
+++ b/tests/unit/relations/test_backend_database.py
@@ -75,11 +75,11 @@ class TestBackendDatabaseRelation(unittest.TestCase):
         mock_event = MagicMock()
         mock_event.username = "mock_user"
         self.backend._on_database_created(mock_event)
+        hash_pw = get_hashed_password(self.backend.auth_user, pw)
 
-        postgres.create_user.assert_called_with(self.backend.auth_user, pw, admin=True)
+        postgres.create_user.assert_called_with(self.backend.auth_user, hash_pw, admin=True)
         _init_auth.assert_has_calls([call([self.backend.database.database, "postgres"])])
 
-        hash_pw = get_hashed_password(self.backend.auth_user, pw)
         _render.assert_any_call(
             f"{PGB_DIR}/userlist.txt", f'"{self.backend.auth_user}" "{hash_pw}"', perms=0o700
         )


### PR DESCRIPTION
## Proposal
Seems like the update to jammy for postgresql switch the default password hashing. This forces md5 mechanism for the pgb auth user.

## Context
<!-- Necessary details to understand the proposed changes. -->

## Release Notes
<!-- A simple bullet-point summary of the changes in this PR. -->

## Testing
<!-- A summary of how this PR has been tested, including automated testing. -->
