### PR TITLE
Set workload version to PGB version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -125,6 +125,17 @@ class PgBouncerCharm(CharmBase):
 
         systemd.daemon_reload()
 
+    @property
+    def version(self) -> str:
+        """Returns the version Pgbouncer."""
+        try:
+            output = subprocess.check_output(["pgbouncer", "--version"])
+            if output:
+                return output.decode().split("\n")[0].split(" ")[1]
+        except Exception:
+            logger.exception("Unable to get Pgbouncer version")
+            return ""
+
     def _on_start(self, _) -> None:
         """On Start hook.
 
@@ -143,6 +154,8 @@ class PgBouncerCharm(CharmBase):
         except systemd.SystemdError as e:
             logger.error(e)
             self.unit.status = BlockedStatus("failed to start pgbouncer")
+
+        self.unit.set_workload_version(self.version)
 
     def _on_leader_elected(self, _):
         self.peers.update_connection()


### PR DESCRIPTION
## Proposal
* [DPE-1514](https://warthogs.atlassian.net/browse/DPE-1514)
* Sets the workload version to what Pgbouncer reports as it's version

## Context
* Essentially the same thing as [PR#67](https://github.com/canonical/pgbouncer-k8s-operator/pull/67) for K8S

## Release Notes
<!-- A simple bullet-point summary of the changes in this PR. -->

## Testing
<!-- A summary of how this PR has been tested, including automated testing. -->


[DPE-1514]: https://warthogs.atlassian.net/browse/DPE-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ