### PR TITLE
Refresh snap due to packages update

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,7 @@ AUTH_FILE_NAME = "userlist.txt"
 # Snap constants.
 PGBOUNCER_EXECUTABLE = "charmed-postgresql.pgbouncer"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 50})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 53})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"


### PR DESCRIPTION
## Issue
Security scan detected outdated packages in the charmed-postgresql snap:
```
Revision r50 (amd64; channels: 14/edge)
 * libpq5: 6104-1
 * postgresql-14: 6104-1
 * postgresql-client-14: 6104-1
 * postgresql-plpython3-14: 6104-1
```

## Solution
Rebuild the snap and updated the held revision