### PR TITLE
[DPE-2049][DPE-2050] Interface limits and revision update

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -53,6 +53,8 @@ requires:
   backend-database:
     interface: postgresql_client
     optional: false
+    limit: 1
   juju-info:
     interface: juju-info
     scope: container
+    limit: 1

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,7 @@ AUTH_FILE_NAME = "userlist.txt"
 # Snap constants.
 PGBOUNCER_EXECUTABLE = "charmed-postgresql.pgbouncer"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 56})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 57})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -5,7 +5,6 @@
 import asyncio
 import json
 import logging
-import subprocess
 from multiprocessing import ProcessError
 from pathlib import Path
 from typing import Dict
@@ -318,37 +317,15 @@ async def deploy_and_relate_application_with_pgbouncer_bundle(
         the id of the created relation.
     """
     # Deploy application.
-    if not force:
-        await ops_test.model.deploy(
-            charm,
-            channel=channel,
-            application_name=application_name,
-            num_units=number_of_units,
-            config=config,
-            series=series,
-        )
-    else:
-        # Dirty hack to force the series
-        status = await ops_test.model.get_status()
-        args = [
-            "juju",
-            "deploy",
-            charm,
-            application_name,
-            "-m",
-            status.model.name,
-            "--force",
-            "-n",
-            str(number_of_units),
-            "--series",
-            series,
-            "--channel",
-            channel,
-        ]
-        if config:
-            for key, val in config.items():
-                args += ["--config", f"{key}={val}"]
-        subprocess.run(args)
+    await ops_test.model.deploy(
+        charm,
+        channel=channel,
+        application_name=application_name,
+        num_units=number_of_units,
+        config=config,
+        series=series,
+        force=force,
+    )
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(

--- a/tests/integration/relations/test_backend_database.py
+++ b/tests/integration/relations/test_backend_database.py
@@ -70,10 +70,7 @@ async def test_relate_pgbouncer_to_postgres(ops_test: OpsTest, application_charm
             for attempt in Retrying(stop=stop_after_delay(3 * 60), wait=wait_fixed(3)):
                 with attempt:
                     cfg = await get_cfg(ops_test, f"{PGB}/0")
-                    if (
-                        pgb_user not in cfg["pgbouncer"]["admin_users"]
-                        and "auth_query" not in cfg["pgbouncer"].keys()
-                    ):
+                    if "auth_query" not in cfg["pgbouncer"].keys():
                         break
         except RetryError:
             assert False, "pgbouncer config files failed to update in 3 minutes"


### PR DESCRIPTION
## Issue
* The PGB charm will break if having multiple backend database relations
* The PGB charm should subordinate to only a single principle
* Snapped psql needs to make network connections

## Solution
* Limit interfaces where we want a one-to-one relationship
* Update to snap revision with fixed psql
* Remove a workaround for forcing the series of charms used for testing (fixed in libjuju)
