### PR TITLE
Update revision due to outdated packages

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,7 @@ AUTH_FILE_NAME = "userlist.txt"
 # Snap constants.
 PGBOUNCER_EXECUTABLE = "charmed-postgresql.pgbouncer"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 61})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 62})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"


### PR DESCRIPTION
## Issue
Security scan report:
```
Revision r61 (amd64; channels: 14/edge)
 * libc-ares2: 6164-1
```

## Solution
Rebuild and update snap