### PR TITLE
[DPE-2055] PGB extensions suport

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,3 +20,4 @@ parts:
   charm:
     charm-binary-python-packages:
       - psycopg2-binary==2.9.6  # renovate
+      - psycopg[binary]==3.1.9  # renovate

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -79,11 +79,11 @@ logger = logging.getLogger(__name__)
 LIBID = "05394e5893f94f2d90feb7cbe6b633cd"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 0
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -222,7 +222,7 @@ class Snap(object):
         name,
         state: SnapState,
         channel: str,
-        revision: int,
+        revision: str,
         confinement: str,
         apps: Optional[List[Dict[str, str]]] = None,
         cohort: Optional[str] = "",
@@ -415,7 +415,7 @@ class Snap(object):
         """Restarts a snap's services.
 
         Args:
-            services (list): (optional) list of individual snap services to show logs from.
+            services (list): (optional) list of individual snap services to restart.
                 (otherwise all)
             reload (bool): (optional) flag to use the service reload command, if available.
                 Default `False`
@@ -427,7 +427,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
     ) -> None:
         """Add a snap to the system.
 
@@ -454,7 +454,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -498,7 +498,7 @@ class Snap(object):
         classic: Optional[bool] = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
     ):
         """Ensure that a snap is in a given state.
 
@@ -575,7 +575,7 @@ class Snap(object):
         self._state = state
 
     @property
-    def revision(self) -> int:
+    def revision(self) -> str:
         """Returns the revision for a snap."""
         return self._revision
 
@@ -828,7 +828,7 @@ class SnapCache(Mapping):
                 name=i["name"],
                 state=SnapState.Latest,
                 channel=i["channel"],
-                revision=int(i["revision"]),
+                revision=i["revision"],
                 confinement=i["confinement"],
                 apps=i.get("apps", None),
             )
@@ -846,7 +846,7 @@ class SnapCache(Mapping):
             name=info["name"],
             state=SnapState.Available,
             channel=info["channel"],
-            revision=int(info["revision"]),
+            revision=info["revision"],
             confinement=info["confinement"],
             apps=None,
         )
@@ -859,7 +859,7 @@ def add(
     channel: Optional[str] = "",
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
-    revision: Optional[int] = None,
+    revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
     """Add a snap to the system.
 
@@ -871,7 +871,7 @@ def add(
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
-        revision: an (Optional) integer specifying the snap revision to use
+        revision: an (Optional) string specifying the snap revision to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
@@ -947,7 +947,7 @@ def _wrap_snap_operations(
     channel: str,
     classic: bool,
     cohort: Optional[str] = "",
-    revision: Optional[int] = None,
+    revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
     """Wrap common operations for bare commands."""
     snaps = {"success": [], "failed": []}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1072,13 +1072,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.6.0"
+version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.6.0-py3-none-any.whl", hash = "sha256:ffa199e3fbab8365778c4a10e1fbf1b9cd50707de826eb304b50e57ec0cc8d38"},
-    {file = "platformdirs-3.6.0.tar.gz", hash = "sha256:57e28820ca8094678b807ff529196506d7a21e17156cb1cddb3e74cebce54640"},
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
 [package.extras]
@@ -1087,13 +1087,13 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-
 
 [[package]]
 name = "pluggy"
-version = "1.0.0"
+version = "1.2.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
 [package.extras]
@@ -1768,13 +1768,13 @@ files = [
 
 [[package]]
 name = "websocket-client"
-version = "1.6.0"
+version = "1.6.1"
 description = "WebSocket client for Python with low level API options"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "websocket-client-1.6.0.tar.gz", hash = "sha256:e84c7eafc66aade6d1967a51dfd219aabdf81d15b9705196e11fd81f48666b78"},
-    {file = "websocket_client-1.6.0-py3-none-any.whl", hash = "sha256:72d7802608745b0a212f79b478642473bd825777d8637b6c8c421bf167790d4f"},
+    {file = "websocket-client-1.6.1.tar.gz", hash = "sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd"},
+    {file = "websocket_client-1.6.1-py3-none-any.whl", hash = "sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -961,6 +961,22 @@ PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [[package]]
+name = "ops-lib-pgsql"
+version = "1.4"
+description = "PostgreSQL database relation for Juju Operator Framework Charms"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "ops-lib-pgsql-1.4.zip", hash = "sha256:3ea802a1a9e6be4457dbe49959a76c50d63b689abc1b803c127bd24e5bd98654"},
+    {file = "ops_lib_pgsql-1.4-py2.py3-none-any.whl", hash = "sha256:85b07a364339da2423c2631680f03aab8f9b4d8a6493efc66303224ff9ab34af"},
+]
+
+[package.dependencies]
+ops = ">=0.8.0"
+pgconnstr = "*"
+PyYAML = "*"
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -1925,4 +1941,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.10"
-content-hash = "aace740335c5e5184fd00a8ca487059d5556fdc4edc9d2fe0caca1d5f5a0be2f"
+content-hash = "5a7406b4804e689387cf361499410681609750d0b07f21c36000548d95d242c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ optional = true
 
 [tool.poetry.group.relation_charm.dependencies]
 ops = "2.3.0"
+ops-lib-pgsql = "1.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
       "extractVersionTemplate": "Juju release"
     }, {
       "fileMatch": ["(^|/)([\\w-]*)charmcraft\\.ya?ml$"],
-      "matchStrings": ["- (?<depName>.*?)==(?<currentValue>.*?) +# renovate"],
+      "matchStrings": ["- (?<depName>.*?)(?:\\[.*?\\])?==(?<currentValue>.*?) +# renovate"],
       "datasourceTemplate": "pypi",
       "versioningTemplate": "loose"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,6 +91,6 @@ tenacity==8.2.2 ; python_full_version >= "3.8.10" and python_full_version < "4.0
 typing-extensions==4.6.3 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
     --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26 \
     --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5
-websocket-client==1.6.1; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
+websocket-client==1.6.1 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
     --hash=sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd \
     --hash=sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,6 +25,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from constants import (
     AUTH_FILE_NAME,
     CLIENT_RELATION_NAME,
+    EXTENSIONS_BLOCKING_MESSAGE,
     INI_NAME,
     MONITORING_PASSWORD_KEY,
     PEER_RELATION_NAME,
@@ -266,6 +267,9 @@ class PgBouncerCharm(CharmBase):
             backend_wait_msg = "waiting for backend database relation to connect"
             logger.warning(backend_wait_msg)
             return BlockedStatus(backend_wait_msg)
+
+        if self.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE:
+            return BlockedStatus(EXTENSIONS_BLOCKING_MESSAGE)
 
         prom_service = f"{PGB}-{self.app.name}-prometheus"
         services = [*self.pgb_services]

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,8 @@ from copy import deepcopy
 from typing import List, Optional, Union
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.operator_libs_linux.v1 import snap, systemd
+from charms.operator_libs_linux.v1 import systemd
+from charms.operator_libs_linux.v2 import snap
 from charms.pgbouncer_k8s.v0 import pgb
 from jinja2 import Template
 from ops.charm import CharmBase

--- a/src/constants.py
+++ b/src/constants.py
@@ -33,3 +33,5 @@ PEER_RELATION_NAME = "pgb-peers"
 CLIENT_RELATION_NAME = "database"
 
 MONITORING_PASSWORD_KEY = "monitoring_password"
+
+EXTENSIONS_BLOCKING_MESSAGE = "bad relation request - remote app requested extensions, which are unsupported. Please remove this relation."

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,7 @@ AUTH_FILE_NAME = "userlist.txt"
 # Snap constants.
 PGBOUNCER_EXECUTABLE = "charmed-postgresql.pgbouncer"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": 62})]
+SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": "62"})]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/tests/integration/relations/pgbouncer_provider/application-charm/metadata.yaml
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/metadata.yaml
@@ -17,3 +17,7 @@ requires:
     interface: postgresql_client
   multiple-database-clusters:
     interface: postgresql_client
+  db:
+    interface: pgsql
+    limit: 1
+    optional: true

--- a/tests/integration/relations/pgbouncer_provider/application-charm/requirements.txt
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/requirements.txt
@@ -1,6 +1,12 @@
+ops-lib-pgsql==1.4 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
+    --hash=sha256:3ea802a1a9e6be4457dbe49959a76c50d63b689abc1b803c127bd24e5bd98654 \
+    --hash=sha256:85b07a364339da2423c2631680f03aab8f9b4d8a6493efc66303224ff9ab34af
 ops==2.3.0 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
     --hash=sha256:24a5c6e985d3f08cb3dfccfd1adb93ca9247dc867b192baaf3265fe5736fd992 \
     --hash=sha256:438c217be75f641948114bc24ecbb2adca2b5e407b401401e1b7dbc0f912731b
+pgconnstr==1.0.1 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
+    --hash=sha256:0656129961ae879675d0842f5237db82d31ce59c7b3211b051c33e37a864826e \
+    --hash=sha256:0f65830e7e3b76adf4390a8592ee52343171a17caef7436257e7bc81c44e21a7
 pyyaml==6.0 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \

--- a/tests/integration/relations/pgbouncer_provider/application-charm/requirements.txt
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/requirements.txt
@@ -42,6 +42,6 @@ pyyaml==6.0 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" 
     --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
-websocket-client==1.6.1; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
+websocket-client==1.6.1 ; python_full_version >= "3.8.10" and python_full_version < "4.0.0" \
     --hash=sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd \
     --hash=sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d

--- a/tests/integration/relations/pgbouncer_provider/application-charm/src/charm.py
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/src/charm.py
@@ -11,6 +11,7 @@ of the libraries in this repository.
 import json
 import logging
 
+import ops.lib
 import psycopg2
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
@@ -22,6 +23,8 @@ from ops.main import main
 from ops.model import ActiveStatus
 
 logger = logging.getLogger(__name__)
+
+pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
 
 # Extra roles that this application needs when interacting with the database.
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
@@ -76,6 +79,11 @@ class ApplicationCharm(CharmBase):
         )
 
         self.framework.observe(self.on.run_sql_action, self._on_run_sql_action)
+
+        self.db = pgsql.PostgreSQLClient(self, "db")
+        self.framework.observe(
+            self.db.on.database_relation_joined, self._on_database_relation_joined
+        )
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
@@ -173,6 +181,21 @@ class ApplicationCharm(CharmBase):
         connection = psycopg2.connect(connstr)
         connection.autocommit = True
         return connection
+
+    def _on_database_relation_joined(
+        self, event: pgsql.DatabaseRelationJoinedEvent  # type: ignore
+    ) -> None:
+        """Handle db-relation-joined.
+
+        Args:
+            event: Event triggering the database relation joined handler.
+        """
+        if self.model.unit.is_leader():
+            event.database = "db_with_extensions"
+            event.extensions = ["pg_trgm:public", "unaccent:public"]
+        elif event.database != "db_with_extensions":
+            event.defer()
+            return
 
 
 if __name__ == "__main__":

--- a/tests/integration/relations/pgbouncer_provider/application-charm/src/charm.py
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/src/charm.py
@@ -193,9 +193,6 @@ class ApplicationCharm(CharmBase):
         if self.model.unit.is_leader():
             event.database = "db_with_extensions"
             event.extensions = ["pg_trgm:public", "unaccent:public"]
-        elif event.database != "db_with_extensions":
-            event.defer()
-            return
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,8 @@ from copy import deepcopy
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import ops.testing
-from charms.operator_libs_linux.v1 import snap, systemd
+from charms.operator_libs_linux.v1 import systemd
+from charms.operator_libs_linux.v2 import snap
 from charms.pgbouncer_k8s.v0 import pgb
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness


### PR DESCRIPTION
## Issue
Pgbouncer would block when a legacy relation requests  extensions even if they are enabled in the backend Postgresql DB

## Solution
* Check for extensions in the backend relation and block accordingly
* Updated snap charm lib
* Since the subordinate unit will be removed on broken relation, there's no need to recheck extensions blocking