### PR TITLE
DPE-2753 Add Discourse documentation + update metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,19 +1,22 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: pgbouncer
-display-name: |
-  PgBouncer Machine Operator
+display-name: PgBouncer
+summary: Charmed PgBouncer VM operator
 description: |
   Lightweight connection pooler for PostgreSQL.
-summary: |
-  The aim of pgbouncer is to lower the performance impact of opening new connections to PostgreSQL. For more information, see https://www.pgbouncer.org/usage.html
-website: |
-  https://www.pgbouncer.org/
-source: |
-  https://github.com/canonical/pgbouncer-operator
-issues: |
-  https://github.com/canonical/pgbouncer-operator/issues
+
+  This charm supports PgBouncer in in bare-metal/virtual-machines.
+docs: https://discourse.charmhub.io/t/pgbouncer-documentation/12133
+source: https://github.com/canonical/pgbouncer-operator
+issues: https://github.com/canonical/pgbouncer-operator/issues
+website:
+  - https://ubuntu.com/data/postgresql
+  - https://charmhub.io/pgbouncer
+  - https://github.com/canonical/pgbouncer-operator
+  - https://chat.charmhub.io/charmhub/channels/data-platform
+  - https://www.pgbouncer.org/
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 


### PR DESCRIPTION
## Issue

* documentation on Discourse was missing
* metadata.yaml was outdated (missing lings, outdated year, wrong summary, etc)

## Solution

We are preparing the charm for release to stable and need to
generate all the necessary documentation/links on https://charmhub.io/pgbouncer

* update metadata.yaml to match pgbouncer-k8s concepts
* add Discourse documentation Overview page
* Also sync all SQL charms layout in metadata.yaml