### PR TITLE
[DPE-3535] Rerender config from secrets during upgrade

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -135,12 +135,12 @@ class PgBouncerCharm(CharmBase):
     #  Charm Lifecycle Hooks
     # =======================
 
-    def render_utility_files(self):
+    def render_utility_files(self, cfg_file=None):
         """Render charm utility services and configuration."""
         # Initialise pgbouncer.ini config files from defaults set in charm lib and current config.
         # We'll add basic configs for now even if this unit isn't a leader, so systemd doesn't
         # throw a fit.
-        if not (cfg_file := self.get_secret(APP_SCOPE, CFG_FILE_DATABAG_KEY)):
+        if not cfg_file:
             cfg_file = pgb.DEFAULT_CONFIG
         cfg = pgb.PgbConfig(cfg_file)
         cfg["pgbouncer"]["listen_addr"] = "127.0.0.1"

--- a/src/charm.py
+++ b/src/charm.py
@@ -140,7 +140,9 @@ class PgBouncerCharm(CharmBase):
         # Initialise pgbouncer.ini config files from defaults set in charm lib and current config.
         # We'll add basic configs for now even if this unit isn't a leader, so systemd doesn't
         # throw a fit.
-        cfg = pgb.PgbConfig(pgb.DEFAULT_CONFIG)
+        if not (cfg_file := self.get_secret(APP_SCOPE, CFG_FILE_DATABAG_KEY)):
+            cfg_file = pgb.DEFAULT_CONFIG
+        cfg = pgb.PgbConfig(cfg_file)
         cfg["pgbouncer"]["listen_addr"] = "127.0.0.1"
         cfg["pgbouncer"]["user"] = "snap_daemon"
         self.render_pgb_config(cfg)

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -18,7 +18,8 @@ from pydantic import BaseModel
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 from typing_extensions import override
 
-from constants import SNAP_PACKAGES
+from constants import APP_SCOPE, SNAP_PACKAGES
+from relations.peers import CFG_FILE_DATABAG_KEY
 
 DEFAULT_MESSAGE = "Pre-upgrade check failed and cannot safely upgrade"
 
@@ -83,7 +84,8 @@ class PgbouncerUpgrade(DataUpgrade):
         self.charm._install_snap_packages(packages=SNAP_PACKAGES, refresh=True)
 
         self.charm.unit.status = MaintenanceStatus("restarting services")
-        self.charm.render_utility_files()
+        cfg = self.charm.get_secret(APP_SCOPE, CFG_FILE_DATABAG_KEY)
+        self.charm.render_utility_files(cfg)
         self.charm.reload_pgbouncer()
         if self.charm.backend.postgres:
             self.charm.render_prometheus_service()

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -40,6 +40,7 @@ class TestUpgrade(unittest.TestCase):
             "Run `juju refresh --revision <previous-revision> pgbouncer` to initiate the rollback"
         )
 
+    @patch("charm.PgBouncerCharm.get_secret")
     @patch("charm.BackendDatabaseRequires.postgres", return_value=True, new_callable=PropertyMock)
     @patch("charm.PgbouncerUpgrade.on_upgrade_changed")
     @patch("charm.PgbouncerUpgrade.set_unit_completed")
@@ -62,6 +63,7 @@ class TestUpgrade(unittest.TestCase):
         _set_unit_completed: Mock,
         _on_upgrade_changed: Mock,
         _,
+        __,
     ):
         event = Mock()
 
@@ -84,6 +86,7 @@ class TestUpgrade(unittest.TestCase):
 
         _on_upgrade_changed.assert_called_once_with(event)
 
+    @patch("charm.PgBouncerCharm.get_secret")
     @patch("upgrade.wait_fixed", return_value=tenacity.wait_fixed(0))
     @patch("charm.BackendDatabaseRequires.postgres", return_value=True, new_callable=PropertyMock)
     @patch("charm.PgbouncerUpgrade.on_upgrade_changed")
@@ -108,6 +111,7 @@ class TestUpgrade(unittest.TestCase):
         _on_upgrade_changed: Mock,
         _,
         __,
+        ___,
     ):
         _cluster_checks.side_effect = ClusterNotReadyError("test", "test")
 


### PR DESCRIPTION
Update rendered a blank config and relied on perpetual peer changed to refresh the configs.