### PR TITLE
[MISC] Architecture specific snap revision

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import platform
 import pwd
 import shutil
 import subprocess
@@ -664,9 +665,15 @@ class PgBouncerCharm(CharmBase):
                 snap_package = snap_cache[snap_name]
 
                 if not snap_package.present or refresh:
-                    if snap_version.get("revision"):
+                    if revision := snap_version.get("revision"):
+                        try:
+                            revision = revision[platform.machine()]
+                        except Exception:
+                            logger.error("Unavailable snap architecture %s", platform.machine())
+                            raise
+                        channel = snap_version.get("channel", "")
                         snap_package.ensure(
-                            snap.SnapState.Latest, revision=snap_version["revision"]
+                            snap.SnapState.Latest, revision=revision, channel=channel
                         )
                         snap_package.hold()
                     else:

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,9 @@ AUTH_FILE_NAME = "userlist.txt"
 # Snap constants.
 PGBOUNCER_EXECUTABLE = "charmed-postgresql.pgbouncer"
 POSTGRESQL_SNAP_NAME = "charmed-postgresql"
-SNAP_PACKAGES = [(POSTGRESQL_SNAP_NAME, {"revision": "98"})]
+SNAP_PACKAGES = [
+    (POSTGRESQL_SNAP_NAME, {"revision": {"aarch64": "97", "x86_64": "98"}, "channel": "14/stable"})
+]
 
 SNAP_COMMON_PATH = "/var/snap/charmed-postgresql/common"
 SNAP_CURRENT_PATH = "/var/snap/charmed-postgresql/current"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import platform
 import unittest
 from copy import deepcopy
 from unittest.mock import MagicMock, PropertyMock, call, patch
@@ -261,11 +262,55 @@ class TestCharm(unittest.TestCase):
         _snap_cache.reset_mock()
         _snap_package.reset_mock()
         _snap_package.ensure.side_effect = None
-        self.charm._install_snap_packages([("postgresql", {"revision": 42})])
+        self.charm._install_snap_packages(
+            [("postgresql", {"revision": {platform.machine(): "42"}})]
+        )
         _snap_cache.assert_called_once_with()
         _snap_cache.return_value.__getitem__.assert_called_once_with("postgresql")
-        _snap_package.ensure.assert_called_once_with(snap.SnapState.Latest, revision=42)
+        _snap_package.ensure.assert_called_once_with(
+            snap.SnapState.Latest, revision="42", channel=""
+        )
         _snap_package.hold.assert_called_once_with()
+
+        # Test with refresh
+        _snap_cache.reset_mock()
+        _snap_package.reset_mock()
+        _snap_package.present = True
+        self.charm._install_snap_packages(
+            [("postgresql", {"revision": {platform.machine(): "42"}, "channel": "latest/test"})],
+            refresh=True,
+        )
+        _snap_cache.assert_called_once_with()
+        _snap_cache.return_value.__getitem__.assert_called_once_with("postgresql")
+        _snap_package.ensure.assert_called_once_with(
+            snap.SnapState.Latest, revision="42", channel="latest/test"
+        )
+        _snap_package.hold.assert_called_once_with()
+
+        # Test without refresh
+        _snap_cache.reset_mock()
+        _snap_package.reset_mock()
+        self.charm._install_snap_packages(
+            [("postgresql", {"revision": {platform.machine(): "42"}})]
+        )
+        _snap_cache.assert_called_once_with()
+        _snap_cache.return_value.__getitem__.assert_called_once_with("postgresql")
+        _snap_package.ensure.assert_not_called()
+        _snap_package.hold.assert_not_called()
+
+        # test missing architecture
+        _snap_cache.reset_mock()
+        _snap_package.reset_mock()
+        _snap_package.present = True
+        with self.assertRaises(KeyError):
+            self.charm._install_snap_packages(
+                [("postgresql", {"revision": {"missingarch": "42"}})],
+                refresh=True,
+            )
+        _snap_cache.assert_called_once_with()
+        _snap_cache.return_value.__getitem__.assert_called_once_with("postgresql")
+        assert not _snap_package.ensure.called
+        assert not _snap_package.hold.called
 
     @patch("os.chmod")
     @patch("os.chown")


### PR DESCRIPTION
Copy of https://github.com/canonical/postgresql-operator/pull/345

Use a different snap depending on CPU architecture.