### PR TITLE
Add `libpq-dev` to charm `build-packages`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,6 +30,7 @@ parts:
       - rustc
       - cargo
       - pkg-config
+      - libpq-dev
     charm-strict-dependencies: true
   libpq:
     build-packages:


### PR DESCRIPTION
`libpq-dev` needed to build `psycopg2` from source

Enables removal of workaround: https://github.com/canonical/charmcraftcache-hub/commit/884b197e323eecbc7afc1bbe4b2bd1dd7f823242
