### PR TITLE
[DPE-4221] Recreate auth_query on backend rerelation

### DIFF
--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -132,7 +132,9 @@ class BackendDatabaseRequires(Object):
                     logger.debug("database %s not yet created", database)
 
         for relation in self.charm.model.relations.get("db-admin", []):
-            database = self.legacy_db_admin_relation.get_databags(relation)[0].get("database")
+            database = self.charm.legacy_db_admin_relation.get_databags(relation)[0].get(
+                "database"
+            )
             if database and relation.units:
                 try:
                     con = self.postgres._connect_to_database(database)

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -123,20 +123,35 @@ class BackendDatabaseRequires(Object):
         databases = [self.database.database, PG]
         for relation in self.charm.model.relations.get("db", []):
             database = self.charm.legacy_db_relation.get_databags(relation)[0].get("database")
-            if database:
-                databases.append(database)
+            if database and relation.units:
+                try:
+                    con = self.postgres._connect_to_database(database)
+                    con.close()
+                    databases.append(database)
+                except psycopg2.OperationalError:
+                    logger.debug("database %s not yet created", database)
 
         for relation in self.charm.model.relations.get("db-admin", []):
             database = self.legacy_db_admin_relation.get_databags(relation)[0].get("database")
-            if database:
-                databases.append(database)
+            if database and relation.units:
+                try:
+                    con = self.postgres._connect_to_database(database)
+                    con.close()
+                    databases.append(database)
+                except psycopg2.OperationalError:
+                    logger.debug("database %s not yet created", database)
 
         for _, data in self.charm.client_relation.database_provides.fetch_relation_data(
             fields=["database"]
         ).items():
             database = data.get("database")
             if database:
-                databases.append(database)
+                try:
+                    con = self.postgres._connect_to_database(database)
+                    con.close()
+                    databases.append(database)
+                except psycopg2.OperationalError:
+                    logger.debug("database %s not yet created", database)
 
         return databases
 

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -118,6 +118,28 @@ class BackendDatabaseRequires(Object):
             charm.on[BACKEND_RELATION_NAME].relation_broken, self._on_relation_broken
         )
 
+    def collect_databases(self) -> List[str]:
+        """Collects the names of all client dbs to inject or remove the auth_query."""
+        databases = [self.database.database, PG]
+        for relation in self.charm.model.relations.get("db", []):
+            database = self.charm.legacy_db_relation.get_databags(relation)[0].get("database")
+            if database:
+                databases.append(database)
+
+        for relation in self.charm.model.relations.get("db-admin", []):
+            database = self.legacy_db_admin_relation.get_databags(relation)[0].get("database")
+            if database:
+                databases.append(database)
+
+        for _, data in self.charm.client_relation.database_provides.fetch_relation_data(
+            fields=["database"]
+        ).items():
+            database = data.get("database")
+            if database:
+                databases.append(database)
+
+        return databases
+
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Handle backend-database-database-created event.
 
@@ -162,7 +184,7 @@ class BackendDatabaseRequires(Object):
         # create authentication user on postgres database, so we can authenticate other users
         # later on
         self.postgres.create_user(self.auth_user, hashed_password, admin=True)
-        self.initialise_auth_function([self.database.database, PG])
+        self.initialise_auth_function(self.collect_databases())
 
         # Add the monitoring user.
         if not (monitoring_password := self.charm.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY)):
@@ -227,7 +249,7 @@ class BackendDatabaseRequires(Object):
             # TODO de-authorise all databases
             logger.info("removing auth user")
             # Remove auth function before broken-hook, while we can still connect to postgres.
-            self.remove_auth_function([PGB, PG])
+            self.remove_auth_function(self.collect_databases())
         except psycopg2.Error:
             remove_auth_fail_msg = (
                 "failed to remove auth user when disconnecting from postgres application."


### PR DESCRIPTION
## Issue
Auth query functions are not readded when backend rerelates

## Solution
Collect existing client rel dbs and add or remove auth_query function on backend rel events