### PR TITLE
Disable ARM integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
             allure_on_amd64: true
         architecture:
           - amd64
-          - arm64
     name: Integration test charm | ${{ matrix.juju.agent }} | ${{ matrix.architecture }}
     needs:
       - lint


### PR DESCRIPTION
Too high cost on GitHub-hosted ARM runners

Will try to re-enable on nightly only if costs are low enough, but disabling all for now so that new PR runs do not create further costs