### PR TITLE
Create sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Sync docs from Discourse
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 30 01 * * *
+
+jobs:
+  sync-docs:
+    name: Sync docs from Discourse
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@main
+    secrets:
+      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
+      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
+    permissions:
+      contents: write  # Needed to push branch & tag
+      pull-requests: write  # Needed to create PR


### PR DESCRIPTION
## Issue
This repository does not have a workflow to sync discourse documentation.

## Solution
* Created `sync_docs.yaml` file based on the [`sync_docs` workflow from data-platform-workflows](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_sync_docs.md).
This workflow runs once a day and calls the [`discourse-gatekeeper`](https://github.com/canonical/discourse-gatekeeper) action to synchronize documentation from charmhub.