### PR TITLE
Shorten integration test job name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
               agent: 3.4.4  # renovate: juju-agent-pin-minor
               allure_on_amd64: true
             architecture: arm64
-    name: Integration test charm | ${{ matrix.juju.agent }} | ${{ matrix.architecture }}
+    name: Integration | ${{ matrix.juju.agent }} | ${{ matrix.architecture }}
     needs:
       - lint
       - unit-test


### PR DESCRIPTION
Follows migration instructions for https://github.com/canonical/data-platform-workflows/releases/tag/v16.3.2
