### PR TITLE
Update sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,10 +10,9 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@20.0.0
-    secrets:
-      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
-      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v20.0.0
+    with:
+      reviewers: a-velasco,izmalk
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR


### PR DESCRIPTION
A [new `sync_docs.yaml` workflow](https://github.com/canonical/data-platform-workflows/pull/220) was released in data-platform-workflows `v19.2.0`. It overwrites the old experimental `_sync_docs.yaml` workflow and releases it to the public interface.

This PR:
* Corrects the filename to match the new syntax without the experimental `_` prefix.
* Removes the now unnecessary Discourse API credentials
* Adds automatic reviewers