### PR TITLE
[DPE-5338] Handle Secret permission error

### DIFF
--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -435,12 +435,16 @@ class BackendDatabaseRequires(Object):
             logger.debug("Backend not ready: no connection info")
             return False
 
-        if (
-            not (auth_file := self.charm.get_secret(APP_SCOPE, AUTH_FILE_DATABAG_KEY))
-            or not self.auth_user
-            or self.auth_user not in auth_file
-        ):
-            logger.debug("Backend not ready: no auth file secret set")
+        try:
+            if (
+                not (auth_file := self.charm.get_secret(APP_SCOPE, AUTH_FILE_DATABAG_KEY))
+                or not self.auth_user
+                or self.auth_user not in auth_file
+            ):
+                logger.debug("Backend not ready: no auth file secret set")
+                return False
+        except ModelError:
+            logger.debug("Backend not ready: Unable to get secret")
             return False
 
         # Check we can actually connect to backend database by running a command.

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -148,7 +148,6 @@ class TestUpgrade(unittest.TestCase):
     @patch("charm.BackendDatabaseRequires.ready", return_value=False, new_callable=PropertyMock)
     @patch("charm.PgBouncerCharm.check_pgb_running", return_value=True)
     def test_pre_upgrade_check_backend_not_ready(self, _check_pgb_running: Mock, _, __):
-        print(self.charm.backend.ready)
         with pytest.raises(ClusterNotReadyError):
             self.charm.upgrade.pre_upgrade_check()
 


### PR DESCRIPTION
Handles uncaught exception:
```

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/./src/charm.py", line 999, in <module>
    main(PgBouncerCharm)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/main.py", line 553, in main
    manager.run()
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/main.py", line 529, in run
    self._emit()
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/main.py", line 518, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/main.py", line 139, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/framework.py", line 347, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/framework.py", line 853, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/framework.py", line 943, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/src/relations/peers.py", line 121, in _on_joined
    self._on_changed(event)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/src/relations/peers.py", line 144, in _on_changed
    self.charm.render_pgb_config(reload_pgbouncer=True)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/./src/charm.py", line 812, in render_pgb_config
    databases = self._get_relation_config()
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/./src/charm.py", line 725, in _get_relation_config
    if not self.backend.relation or not (databases := self.get_relation_databases()):
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/./src/charm.py", line 662, in get_relation_databases
    if cfg := self.get_secret(APP_SCOPE, CFG_FILE_DATABAG_KEY):
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/./src/charm.py", line 331, in get_secret
    return self.peer_relation_data(scope).get_secret(peers.id, secret_key)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 517, in wrapper
    return f(self, *args, **kwargs)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 2028, in get_secret
    and full_field not in self.current_secret_fields
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1985, in current_secret_fields
    if content := self._get_group_secret_contents(relation, group):
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 2316, in _get_group_secret_contents
    result = super()._get_group_secret_contents(relation, group, secret_fields)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1119, in _get_group_secret_contents
    if (secret := self._get_relation_secret(relation.id, group)) and (
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 504, in wrapper
    return f(self, *args, **kwargs)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 2303, in _get_relation_secret
    return self.secrets.get(
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 808, in get
    if secret.meta:
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 638, in meta
    self._secret_meta = self._model.get_secret(label=self.label)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/model.py", line 299, in get_secret
    content = self._backend.secret_get(id=id, label=label)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/model.py", line 3579, in secret_get
    result = self._run('secret-get', *args, return_output=True, use_json=True)
  File "/var/lib/juju/agents/unit-pgbouncer-2/charm/venv/ops/model.py", line 3215, in _run
    raise ModelError(e.stderr) from e
ops.model.ModelError: ERROR permission denied
```