### PR TITLE
[MISC] Use the same build job in release and ci workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,8 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.4
+    # self-hosted-builders branch is a temporary solution to reduce runner costs until https://github.com/canonical/charmcraftcache-hub/issues/111 is fixed 
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@self-hosted-builders
 
   release:
     name: Release charm


### PR DESCRIPTION
Release flow fails due to mismatch of build jobs in the CI and release flow [E.g.](https://github.com/canonical/pgbouncer-operator/actions/runs/11742113069/job/32712167513):

```
ValueError: Cannot resolve multiple versions found for 
reusable_workflow_file_name='build_charm.yaml' 
reusable_workflow_repository='canonical/data-platform-workflows':
• v23.0.4 (60f088b7f0f967a8e35d45339f5123a6e74786f7)
• self-hosted-builders (a8d92a8c9200c0e491ce608705c8adff0ad70b87)
```