### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ env_list = lint, unit
 [vars]
 src_path = "{tox_root}/src"
 tests_path = "{tox_root}/tests"
-test_charm_libs = "{tox_root}/tests/integration/relations/pgbouncer_provider/application-charm/lib"
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
@@ -41,8 +40,7 @@ commands =
     poetry check --lock
     poetry run codespell "{tox_root}" --skip "{tox_root}/.git" --skip "{tox_root}/.tox" \
       --skip "{tox_root}/build" --skip "{tox_root}/lib" --skip "{tox_root}/venv" \
-      --skip "{tox_root}/.mypy_cache" --skip "{tox_root}/LICENSE" --skip "{tox_root}/poetry.lock" \
-      --skip {[vars]test_ha_charm_libs} --skip {[vars]test_rel_charm_libs}
+      --skip "{tox_root}/.mypy_cache" --skip "{tox_root}/LICENSE" --skip "{tox_root}/poetry.lock"
     # pflake8 wrapper supports config from pyproject.toml
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/pgbouncer-operator/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/PostgreSQL"
$ cd "Projects/Canonical/Data Platform/PostgreSQL"
$ git clone https://github.com/canonical/pgbouncer-operator
$ cd pgbouncer-operator
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/pgbouncer-operator/src:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/pgbouncer-operator/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.