### PR TITLE
[MISC] Sanitize PostgreSQL extra-user-roles arg

### DIFF
--- a/lib/charms/postgresql_k8s/v0/postgresql.py
+++ b/lib/charms/postgresql_k8s/v0/postgresql.py
@@ -35,7 +35,10 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 42
+LIBPATCH = 45
+
+# Groups to distinguish database permissions
+PERMISSIONS_GROUP_ADMIN = "admin"
 
 INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE = "invalid role(s) for extra user roles"
 
@@ -187,7 +190,7 @@ class PostgreSQL:
                     Identifier(database)
                 )
             )
-            for user_to_grant_access in [user, "admin", *self.system_users]:
+            for user_to_grant_access in [user, PERMISSIONS_GROUP_ADMIN, *self.system_users]:
                 cursor.execute(
                     SQL("GRANT ALL PRIVILEGES ON DATABASE {} TO {};").format(
                         Identifier(database), Identifier(user_to_grant_access)
@@ -220,7 +223,7 @@ class PostgreSQL:
         user: str,
         password: Optional[str] = None,
         admin: bool = False,
-        extra_user_roles: Optional[str] = None,
+        extra_user_roles: Optional[List[str]] = None,
     ) -> None:
         """Creates a database user.
 
@@ -235,16 +238,17 @@ class PostgreSQL:
             admin_role = False
             roles = privileges = None
             if extra_user_roles:
-                extra_user_roles = tuple(extra_user_roles.lower().split(","))
-                admin_role = "admin" in extra_user_roles
+                admin_role = PERMISSIONS_GROUP_ADMIN in extra_user_roles
                 valid_privileges, valid_roles = self.list_valid_privileges_and_roles()
                 roles = [
-                    role for role in extra_user_roles if role in valid_roles and role != "admin"
+                    role
+                    for role in extra_user_roles
+                    if role in valid_roles and role != PERMISSIONS_GROUP_ADMIN
                 ]
                 privileges = {
                     extra_user_role
                     for extra_user_role in extra_user_roles
-                    if extra_user_role not in roles and extra_user_role != "admin"
+                    if extra_user_role not in roles and extra_user_role != PERMISSIONS_GROUP_ADMIN
                 }
                 invalid_privileges = [
                     privilege for privilege in privileges if privilege not in valid_privileges
@@ -566,8 +570,8 @@ END; $$;"""
                         )
                     )
                 self.create_user(
-                    "admin",
-                    extra_user_roles="pg_read_all_data,pg_write_all_data",
+                    PERMISSIONS_GROUP_ADMIN,
+                    extra_user_roles=["pg_read_all_data", "pg_write_all_data"],
                 )
                 cursor.execute("GRANT CONNECT ON DATABASE postgres TO admin;")
         except psycopg2.Error as e:

--- a/src/relations/pgbouncer_provider.py
+++ b/src/relations/pgbouncer_provider.py
@@ -37,6 +37,7 @@ f"{dbname}_readonly".
 
 import logging
 from hashlib import shake_128
+from typing import List, Optional
 from urllib.parse import quote
 
 from charms.data_platform_libs.v0.data_interfaces import (
@@ -45,6 +46,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 )
 from charms.pgbouncer_k8s.v0 import pgb
 from charms.postgresql_k8s.v0.postgresql import (
+    PERMISSIONS_GROUP_ADMIN,
     PostgreSQLCreateDatabaseError,
     PostgreSQLCreateUserError,
     PostgreSQLDeleteUserError,
@@ -96,6 +98,14 @@ class PgBouncerProvider(Object):
             charm.on[self.relation_name].relation_broken, self._on_relation_broken
         )
 
+    @staticmethod
+    def sanitize_extra_roles(extra_roles: Optional[str]) -> List[str]:
+        """Standardize and sanitize user extra-roles."""
+        if extra_roles is None:
+            return []
+
+        return [role.lower() for role in extra_roles.split(",")]
+
     def _depart_flag(self, relation):
         return f"{self.relation_name}_{relation.id}_departing"
 
@@ -128,13 +138,19 @@ class PgBouncerProvider(Object):
 
         # Retrieve the database name and extra user roles using the charm library.
         database = event.database
-        extra_user_roles = event.extra_user_roles or ""
+
+        # Make sure that certain groups are not in the list
+        extra_user_roles = self.sanitize_extra_roles(event.extra_user_roles)
 
         dbs = self.charm.generate_relation_databases()
-        dbs[str(event.relation.id)] = {"name": database, "legacy": False}
-        roles = extra_user_roles.lower().split(",")
-        if "admin" in roles or "superuser" in roles or "createdb" in roles:
+        dbs[str(rel_id)] = {"name": database, "legacy": False}
+        if (
+            PERMISSIONS_GROUP_ADMIN in extra_user_roles
+            or "superuser" in extra_user_roles
+            or "createdb" in extra_user_roles
+        ):
             dbs["*"] = {"name": "*", "auth_dbname": database}
+
         self.charm.set_relation_databases(dbs)
 
         pgb_dbs_hash = shake_128(

--- a/tests/unit/relations/test_pgbouncer_provider.py
+++ b/tests/unit/relations/test_pgbouncer_provider.py
@@ -122,10 +122,14 @@ class TestPgbouncerProvider(unittest.TestCase):
 
         # Verify we've called everything we should
         _pg().create_user.assert_called_with(
-            user, _password(), extra_user_roles=event.extra_user_roles
+            user,
+            _password(),
+            extra_user_roles=[role.lower() for role in event.extra_user_roles.split(",")],
         )
         _pg().create_database.assert_called_with(
-            database, user, client_relations=sentinel.client_rels
+            database,
+            user,
+            client_relations=sentinel.client_rels,
         )
         _dbp_set_credentials.assert_called_with(rel_id, user, _password())
         _dbp_set_version.assert_called_with(rel_id, _pg().get_postgresql_version())


### PR DESCRIPTION
This PR contains a slight refactor to sync code with PostgreSQL VM / K8s operator codebases.

Changes:
- Start leveraging PostgreSQL lib `PERMISSIONS_GROUP_ADMIN` constant.
- Start passing PostgreSQL lib create-user `extra_user_roles` argument  as a list.