### PR TITLE
[MISC] Use latest/stable lxd

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -5,6 +5,7 @@ providers:
   lxd:
     enable: true
     bootstrap: true
+    channel: latest/stable
 host:
   snaps:
     jhack:


### PR DESCRIPTION
Default branch for lxd is 5.2, while latest is 6.3.