### PR TITLE
Re-enable unstable test to gather the current test status

### DIFF
--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -377,7 +377,6 @@ async def test_scaling(ops_test: OpsTest):
         )
 
 
-@pytest.mark.skip(reason="Unstable")
 async def test_relation_broken(ops_test: OpsTest):
     """Test that the user is removed when the relation is broken."""
     # Retrieve the relation user.


### PR DESCRIPTION
## Issue

One test was disable for a while

## Solution

Let's re-enable it to collect the current stats for the test
(after the recent and  major stabilization for PG and PGB).