### PR TITLE
[DPE-10646] Conditionally add discard directives

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -930,6 +930,7 @@ class PgBouncerCharm(TypedCharmBase):
                             key_file=f"{app_conf_dir}/{TLS_KEY_FILE}",
                             ca_file=f"{app_conf_dir}/{TLS_CA_FILE}",
                             cert_file=f"{app_conf_dir}/{TLS_CERT_FILE}",
+                            backend_version=self.backend.backend_major_version,
                         ),
                         0o700,
                     )

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -453,7 +453,7 @@ class BackendDatabaseRequires(Object):
             database=database,
         )
 
-    @property
+    @cached_property
     def backend_version(self) -> str:
         """Backend Postgresql version."""
         if not self.relation:
@@ -462,6 +462,17 @@ class BackendDatabaseRequires(Object):
         if version := self.database.fetch_relation_field(self.relation.id, "version"):
             return version
         return ""
+
+    @cached_property
+    def backend_major_version(self) -> int:
+        """Backend Postgresql version."""
+        if not self.relation or self.backend_version:
+            return 0
+
+        try:
+            return int(self.backend_version.split(".")[0])
+        except ValueError:
+            return 0
 
     @property
     def auth_user(self) -> Optional[str]:

--- a/templates/pgb_config.j2
+++ b/templates/pgb_config.j2
@@ -42,6 +42,5 @@ client_tls_cert_file = {{ cert_file }}
 client_tls_sslmode = prefer
 {% endif %}
 {% if backend_version > 16 -%}
-server_reset_query = DISCARD ALL; LOAD 'login_hook';
-server_reset_query_always = 1
+server_reset_query = CLOSE ALL; RESET ALL; DEALLOCATE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD TEMP; DISCARD SEQUENCES;
 {% endif %}

--- a/templates/pgb_config.j2
+++ b/templates/pgb_config.j2
@@ -41,5 +41,7 @@ client_tls_ca_file = {{ ca_file }}
 client_tls_cert_file = {{ cert_file }}
 client_tls_sslmode = prefer
 {% endif %}
+{% if backend_version > 16 -%}
 server_reset_query = DISCARD ALL; LOAD 'login_hook';
 server_reset_query_always = 1
+{% endif %}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -418,6 +418,7 @@ class TestCharm(unittest.TestCase):
             auth_query="SELECT username, password FROM pgbouncer_auth_BACKNEND_USER.get_auth($1)",
             auth_file=auth_file,
             enable_tls=False,
+            backend_version=16,
         )
         _render.assert_called_once_with(
             f"{PGB_CONF_DIR}/pgbouncer/instance_0/pgbouncer.ini", expected_content, 0o700
@@ -467,6 +468,7 @@ class TestCharm(unittest.TestCase):
             auth_query="SELECT username, password FROM pgbouncer_auth_BACKNEND_USER.get_auth($1)",
             auth_file=auth_file,
             enable_tls=False,
+            backend_version=16,
         )
         _render.assert_called_once_with(
             f"{PGB_CONF_DIR}/pgbouncer/instance_0/pgbouncer.ini", expected_content, 0o700


### PR DESCRIPTION
Relates to https://github.com/canonical/pgbouncer-operator/issues/690

## Issue
When adapting the charm to Postgresql 16 charm roles management, we added a workaround for recycled connections, so that the `charmed_{dbname}_owner` role is not lost. The workaround generates excessive error logs in the Postgresql charm and does not properly recycle the relation.

## Solution
The workaround is not necessary for Postgresql 14 charm, since roles work differently and for Postgresql 16 charm it should match the discard command without resetting the role.
